### PR TITLE
Allow compilation on Intel Silicon x86 Mac

### DIFF
--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Build llama.cpp for Mac (Apple Silicon / Metal)
+# Build llama.cpp for Mac — Apple Silicon (Metal) or Intel (CPU only).
 # Prerequisites: Xcode command-line tools, cmake
 # Usage: ./scripts/build_mac.sh [path_to_llama_cpp_repo]
 set -e
@@ -26,21 +26,43 @@ if [ -d "$DEST" ]; then
     rm -rf "$DEST"
 fi
 
-# ── Build (native-optimized for this Mac) ──
-step "Building llama.cpp for Mac (Apple Silicon / Metal) ..."
+MAC_ARCH="$(uname -m)"
+
+# ── Build (native for this Mac) ──
 echo "  Repo:    $REPO_DIR"
 echo "  Targets: $TARGETS"
+echo "  Arch:    $MAC_ARCH"
 
 cd "$REPO_DIR"
-cmake -B build-mac \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_OSX_ARCHITECTURES=arm64 \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-    -DGGML_METAL=ON \
-    -DGGML_METAL_EMBED_LIBRARY=ON \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DGGML_STATIC=ON \
-    -DLLAMA_OPENSSL=OFF
+case "$MAC_ARCH" in
+    arm64)
+        step "Building llama.cpp (Apple Silicon + Metal) ..."
+        cmake -B build-mac \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
+            -DGGML_METAL=ON \
+            -DGGML_METAL_EMBED_LIBRARY=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_STATIC=ON \
+            -DLLAMA_OPENSSL=OFF
+        ;;
+    x86_64)
+        step "Building llama.cpp (Intel macOS, CPU — no pre-built binaries in releases) ..."
+        cmake -B build-mac \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+            -DGGML_METAL=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_STATIC=ON \
+            -DLLAMA_OPENSSL=OFF
+        ;;
+    *)
+        err "Unsupported Mac architecture: $MAC_ARCH"
+        exit 1
+        ;;
+esac
 
 cmake --build build-mac --target $TARGETS -j$(sysctl -n hw.logicalcpu)
 cd - > /dev/null

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -80,6 +80,15 @@ download() {
 
 CTX_SIZE_DEFAULT=0
 
+# llama.cpp -ngl: Intel macOS CPU builds use 0; Apple Silicon / CUDA use GPU offload.
+bonsai_llama_ngl() {
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+        echo 0
+    else
+        echo 99
+    fi
+}
+
 get_context_size_fallback() {
     if [ "$(uname -s)" = "Darwin" ]; then
         _mem_gb=$(( $(sysctl -n hw.memsize) / 1073741824 ))

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -15,10 +15,32 @@ BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TA
 
 OS="$(uname -s)"
 
+# True if llama-cli in this dir runs on the host (catches arm64 bin on Intel Mac, etc.).
+_binaries_usable() {
+    _dir="$1"
+    [ -x "$_dir/llama-cli" ] || return 1
+    if "$_dir/llama-cli" --version >/dev/null 2>&1; then
+        return 0
+    fi
+    "$_dir/llama-cli" --help >/dev/null 2>&1
+}
+
 case "$OS" in
     Darwin)
-        ASSET="llama-${RELEASE_TAG}-bin-macos-arm64.tar.gz"
         DEST="bin/mac"
+        MAC_ARCH="$(uname -m)"
+        case "$MAC_ARCH" in
+            arm64)
+                ASSET="llama-${RELEASE_TAG}-bin-macos-arm64.tar.gz"
+                ;;
+            x86_64)
+                ASSET=""
+                ;;
+            *)
+                err "Unsupported Mac architecture: $MAC_ARCH"
+                exit 1
+                ;;
+        esac
         ;;
     Linux)
         # Detect CUDA version
@@ -64,12 +86,26 @@ case "$OS" in
         ;;
 esac
 
-URL="$BASE_URL/$ASSET"
-
 if [ -d "$DEST" ] && ls "$DEST"/llama-* >/dev/null 2>&1; then
-    info "Binaries already present in $DEST/"
-    exit 0
+    if _binaries_usable "$DEST"; then
+        info "Binaries already present in $DEST/"
+        exit 0
+    fi
+    warn "Existing binaries in $DEST/ do not run on this Mac ($(uname -m)) — removing."
+    rm -rf "$DEST"
 fi
+
+# Intel macOS: Prism releases only ship arm64; must build from source.
+if [ "$OS" = "Darwin" ] && [ -z "$ASSET" ]; then
+    echo ""
+    err "No pre-built Prism llama.cpp for Intel macOS (releases are Apple Silicon only)."
+    echo "  Build for x86_64 CPU:"
+    echo "    ./scripts/build_mac.sh"
+    echo ""
+    exit 1
+fi
+
+URL="$BASE_URL/$ASSET"
 
 step "Downloading $ASSET ..."
 echo "  From: $URL"

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -19,10 +19,10 @@ OS="$(uname -s)"
 _binaries_usable() {
     _dir="$1"
     [ -x "$_dir/llama-cli" ] || return 1
-    if "$_dir/llama-cli" --version >/dev/null 2>&1; then
+    if LD_LIBRARY_PATH="$_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$_dir/llama-cli" --version >/dev/null 2>&1; then
         return 0
     fi
-    "$_dir/llama-cli" --help >/dev/null 2>&1
+    LD_LIBRARY_PATH="$_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$_dir/llama-cli" --help >/dev/null 2>&1
 }
 
 case "$OS" in

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -91,7 +91,7 @@ if [ -d "$DEST" ] && ls "$DEST"/llama-* >/dev/null 2>&1; then
         info "Binaries already present in $DEST/"
         exit 0
     fi
-    warn "Existing binaries in $DEST/ do not run on this Mac ($(uname -m)) — removing."
+    warn "Existing binaries in $DEST/ are not usable on this host (OS=$(uname -s), arch=$(uname -m)) — removing."
     rm -rf "$DEST"
 fi
 

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -5,10 +5,12 @@
 #   ./scripts/download_models.sh              # download 8B (default)
 #   BONSAI_MODEL=4B ./scripts/download_models.sh   # download 4B
 #   BONSAI_MODEL=1.7B ./scripts/download_models.sh # download 1.7B
+#   BONSAI_SKIP_MLX=1 ...                          # skip MLX weights (or auto-skip on Intel Mac)
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPT_DIR/common.sh"
+. "$SCRIPT_DIR/mlx_skip.sh"
 assert_valid_model
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
@@ -61,8 +63,8 @@ download_size() {
         info "GGUF ${_size} downloaded to ${_gguf_dir}/"
     fi
 
-    # MLX (macOS only)
-    if [ "$(uname -s)" = "Darwin" ]; then
+    # MLX (macOS + Apple Silicon only; skipped on Intel or when BONSAI_SKIP_MLX=1)
+    if [ "$(uname -s)" = "Darwin" ] && ! bonsai_should_skip_mlx; then
         if [ -d "$_mlx_dir" ] && [ -f "$_mlx_dir/config.json" ]; then
             info "MLX ${_size} already present in ${_mlx_dir}/"
         else
@@ -79,6 +81,8 @@ download_size "$BONSAI_MODEL"
 
 if [ "$(uname -s)" != "Darwin" ]; then
     info "Skipping MLX models (macOS only)."
+elif bonsai_should_skip_mlx; then
+    info "Skipping MLX weights (Intel macOS or BONSAI_SKIP_MLX=1)."
 fi
 
 echo ""

--- a/scripts/mlx_skip.sh
+++ b/scripts/mlx_skip.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Sourced by setup.sh and download_models.sh (not run directly).
+# MLX is Apple Silicon only; Intel macOS cannot build or run it.
+
+# Return 0 = skip MLX (no weights download, no pip build).
+bonsai_should_skip_mlx() {
+    case "${BONSAI_SKIP_MLX:-}" in
+        1|true|yes) return 0 ;;
+        0|false|no) return 1 ;;
+        *)
+            [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ] && return 0
+            return 1 ;;
+    esac
+}

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -23,28 +23,54 @@ for _d in bin/mac bin/cuda llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp
 done
 if [ -z "$BIN" ]; then
     err "llama-cli not found. Run ./setup.sh or ./scripts/download_binaries.sh first."
+    echo "  Intel Mac: there is no arm64 pre-build — use ./scripts/build_mac.sh"
     exit 1
 fi
+
+NGL=$(bonsai_llama_ngl)
 
 # ── Library path for bundled shared libs (needed on Linux CUDA, harmless elsewhere) ──
 BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"
 export LD_LIBRARY_PATH="$BIN_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
+# If you pass -c N, we do not inject -c 0 / fallback (those messages were misleading).
+USER_CTX=""
+_prev=""
+for _a in "$@"; do
+    if [ "$_prev" = "-c" ]; then
+        USER_CTX="$_a"
+        break
+    fi
+    _prev="$_a"
+done
+
 info "Model:  $MODEL"
 info "Binary: $BIN"
-info "Using -c 0 (auto-fit to available memory)"
+if [ -n "$USER_CTX" ]; then
+    info "Context: -c $USER_CTX (from your arguments; no auto-fit / fallback)"
+else
+    info "Context: -c 0 (auto-fit RAM); pass -c N to set explicitly"
+fi
 
-"$BIN" -m "$MODEL" -ngl 99 -c "$CTX_SIZE_DEFAULT" --log-disable \
-    --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
-    --reasoning-budget 0 --reasoning-format none \
-    --chat-template-kwargs '{"enable_thinking": false}' \
-    "$@" 2>/dev/null \
-|| {
-    CTX_SIZE=$(get_context_size_fallback)
-    warn "Auto-fit not supported, falling back to -c $CTX_SIZE"
-    "$BIN" -m "$MODEL" -ngl 99 -c "$CTX_SIZE" --log-disable \
+if [ -n "$USER_CTX" ]; then
+    "$BIN" -m "$MODEL" -ngl "$NGL" --log-disable \
         --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
         --reasoning-budget 0 --reasoning-format none \
         --chat-template-kwargs '{"enable_thinking": false}' \
-        "$@" 2>/dev/null
-}
+        "$@"
+else
+    "$BIN" -m "$MODEL" -ngl "$NGL" -c "$CTX_SIZE_DEFAULT" --log-disable \
+        --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
+        --reasoning-budget 0 --reasoning-format none \
+        --chat-template-kwargs '{"enable_thinking": false}' \
+        "$@" \
+    || {
+        CTX_SIZE=$(get_context_size_fallback)
+        warn "First run failed (often: this build does not support -c 0 auto-fit). Retrying with -c $CTX_SIZE"
+        "$BIN" -m "$MODEL" -ngl "$NGL" -c "$CTX_SIZE" --log-disable \
+            --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
+            --reasoning-budget 0 --reasoning-format none \
+            --chat-template-kwargs '{"enable_thinking": false}' \
+            "$@"
+    }
+fi

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -40,6 +40,8 @@ fi
 BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"
 export LD_LIBRARY_PATH="$BIN_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
+NGL=$(bonsai_llama_ngl)
+
 echo ""
 echo "=== llama.cpp server (GGUF) ==="
 echo "  Model:   $(basename "$MODEL")"
@@ -51,7 +53,7 @@ echo "  API:  http://localhost:$PORT/v1/chat/completions"
 echo "  Press Ctrl+C to stop."
 echo ""
 
-exec "$BIN" -m "$MODEL" --host "$HOST" --port "$PORT" -ngl 99 -c "$CTX_SIZE_DEFAULT" \
+exec "$BIN" -m "$MODEL" --host "$HOST" --port "$PORT" -ngl "$NGL" -c "$CTX_SIZE_DEFAULT" \
     --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
     --reasoning-budget 0 --reasoning-format none \
     --chat-template-kwargs '{"enable_thinking": false}' \

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -84,8 +84,9 @@ else
     if [ -n "$_model" ] && [ -n "$_bin" ]; then
         step "Starting llama-server on port $LLAMA_PORT ..."
         _bin_dir="$(cd "$(dirname "$_bin")" && pwd)"
+        _ngl=$(bonsai_llama_ngl)
         LD_LIBRARY_PATH="$_bin_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        "$_bin" -m "$_model" --host 0.0.0.0 --port "$LLAMA_PORT" -ngl 99 -c "$CTX_SIZE_DEFAULT" \
+        "$_bin" -m "$_model" --host 0.0.0.0 --port "$LLAMA_PORT" -ngl "$_ngl" -c "$CTX_SIZE_DEFAULT" \
             --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
             --reasoning-budget 0 --reasoning-format none \
             --chat-template-kwargs '{"enable_thinking": false}' \

--- a/setup.sh
+++ b/setup.sh
@@ -246,8 +246,15 @@ else
 fi
 
 # ────────────────────────────────────────────────────
-#  7. llama.cpp pre-built binaries
+#  7. llama.cpp pre-built binaries (or Intel Mac: build from source)
 # ────────────────────────────────────────────────────
+if [ "$OS" = "Darwin" ] && [ -x bin/mac/llama-cli ]; then
+    if ! bin/mac/llama-cli --version >/dev/null 2>&1 && ! bin/mac/llama-cli --help >/dev/null 2>&1; then
+        warn "bin/mac/llama-cli does not run on this Mac — removing (wrong CPU arch?)."
+        rm -rf bin/mac
+    fi
+fi
+
 _has_binaries=false
 for _d in bin/mac bin/cuda; do
     ls "$_d"/llama-* >/dev/null 2>&1 && _has_binaries=true && break
@@ -255,6 +262,9 @@ done
 
 if [ "$_has_binaries" = true ]; then
     info "llama.cpp binaries already present."
+elif [ "$OS" = "Darwin" ] && [ "$ARCH" = "x86_64" ]; then
+    step "Intel macOS: building llama.cpp from source (GitHub releases are Apple Silicon only; ~few min) ..."
+    sh "$SCRIPT_DIR/scripts/build_mac.sh"
 else
     sh "$SCRIPT_DIR/scripts/download_binaries.sh"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -5,11 +5,13 @@
 # Usage:
 #   ./setup.sh                      (downloads 8B model by default)
 #   BONSAI_MODEL=4B ./setup.sh      (download a different model size)
+#   BONSAI_SKIP_MLX=1 ./setup.sh    (force GGUF-only: skip MLX on Apple Silicon too)
 set -e
 
 # ── Resolve paths ──
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
+. "$SCRIPT_DIR/scripts/mlx_skip.sh"
 
 VENV_DIR="$SCRIPT_DIR/.venv"
 VENV_PY="$VENV_DIR/bin/python"
@@ -120,7 +122,15 @@ echo ""
 #  2. Detect platform
 # ────────────────────────────────────────────────────
 OS="$(uname -s)"
-step "Detected platform: $OS"
+ARCH="$(uname -m)"
+step "Detected platform: $OS ($ARCH)"
+if [ "$OS" = "Darwin" ] && [ "$ARCH" = "x86_64" ]; then
+    case "${BONSAI_SKIP_MLX:-}" in
+        0|false|no)
+            warn "x86_64 macOS: MLX is unsupported; the MLX step will fail. Use GGUF: ./scripts/run_llama.sh — or omit BONSAI_SKIP_MLX=0."
+            ;;
+    esac
+fi
 
 # ────────────────────────────────────────────────────
 #  2. System dependencies
@@ -231,7 +241,8 @@ if ls "models/gguf/${BONSAI_MODEL}"/*.gguf >/dev/null 2>&1; then
     info "Model already present — skipping download."
     echo "  (Delete models/gguf/${BONSAI_MODEL}/ and re-run to re-download.)"
 else
-    BONSAI_MODEL="$BONSAI_MODEL" sh "$SCRIPT_DIR/scripts/download_models.sh"
+    BONSAI_MODEL="$BONSAI_MODEL" BONSAI_SKIP_MLX="${BONSAI_SKIP_MLX:-}" \
+        sh "$SCRIPT_DIR/scripts/download_models.sh"
 fi
 
 # ────────────────────────────────────────────────────
@@ -251,12 +262,16 @@ fi
 chmod +x "$SCRIPT_DIR"/scripts/*.sh 2>/dev/null || true
 
 echo ""
-info "llama.cpp is ready! You can start using it now while MLX builds."
+if bonsai_should_skip_mlx; then
+    info "llama.cpp is ready! (MLX skipped — Intel Mac or BONSAI_SKIP_MLX=1; use ./scripts/run_llama.sh.)"
+else
+    info "llama.cpp is ready! You can start using it now while MLX builds."
+fi
 
 # ────────────────────────────────────────────────────
 #  8. MLX (macOS only) — clone and build from source
 # ────────────────────────────────────────────────────
-if [ "$OS" = "Darwin" ]; then
+if [ "$OS" = "Darwin" ] && ! bonsai_should_skip_mlx; then
     step "Setting up MLX (Apple Silicon) ..."
     if [ -d "mlx" ]; then
         info "MLX repo already present."
@@ -274,6 +289,8 @@ if [ "$OS" = "Darwin" ]; then
         "safetensors==0.7.0" "tokenizers==0.22.2" "sentencepiece==0.2.1" \
         "protobuf==7.34.0" "numpy==2.4.2" "gguf==0.18.0"
     info "MLX installed."
+elif [ "$OS" = "Darwin" ]; then
+    step "Skipping MLX (Intel/x86_64 macOS or BONSAI_SKIP_MLX=1 — GGUF + llama.cpp only)."
 fi
 
 # ────────────────────────────────────────────────────


### PR DESCRIPTION
For platforms that do not have Metal (Darwin x86), allow build from source for proper compilation. 