### PR TITLE
new release + amd gpu support

### DIFF
--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -45,7 +45,10 @@ case "$OS" in
                 _cuda_tag="13.1"
             elif [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; then
                 _cuda_tag="12.8"
+            elif [ "$_major" -eq 12 ]; then
+                _cuda_tag="12.4"
             else
+                warn "Detected CUDA $_cuda_ver — no matching build available, falling back to CUDA 12.4"
                 _cuda_tag="12.4"
             fi
             info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 
-RELEASE_TAG="prism-b8196-f5dda72"
+RELEASE_TAG="prism-b8201-ba7e817"
 BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TAG"
 
 OS="$(uname -s)"
@@ -21,8 +21,11 @@ case "$OS" in
         DEST="bin/mac"
         ;;
     Linux)
-        # Detect CUDA version
+        # ── Detect GPU: NVIDIA (CUDA) or AMD (ROCm) ──
+        _gpu_type=""
         _cuda_ver=""
+
+        # Check for NVIDIA first
         if command -v nvcc >/dev/null 2>&1; then
             _cuda_ver=$(nvcc --version 2>/dev/null | sed -n 's/.*release \([0-9]*\.[0-9]*\).*/\1/p')
         elif command -v nvidia-smi >/dev/null 2>&1; then
@@ -30,6 +33,12 @@ case "$OS" in
         fi
 
         if [ -n "$_cuda_ver" ]; then
+            _gpu_type="cuda"
+        elif command -v rocminfo >/dev/null 2>&1 || command -v rocm-smi >/dev/null 2>&1 || command -v hipcc >/dev/null 2>&1; then
+            _gpu_type="rocm"
+        fi
+
+        if [ "$_gpu_type" = "cuda" ]; then
             _major="${_cuda_ver%%.*}"
             _minor="${_cuda_ver#*.}"
             if [ "$_major" -ge 13 ]; then
@@ -40,23 +49,28 @@ case "$OS" in
                 _cuda_tag="12.4"
             fi
             info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"
+            ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-${_cuda_tag}-x64.tar.gz"
+            DEST="bin/cuda"
+        elif [ "$_gpu_type" = "rocm" ]; then
+            info "Detected AMD ROCm → using ROCm 7.2 build"
+            ASSET="llama-${RELEASE_TAG}-bin-linux-rocm-7.2-x64.tar.gz"
+            DEST="bin/rocm"
         else
             echo ""
-            echo "  Available CUDA builds:"
-            echo "    1) CUDA 12.4"
-            echo "    2) CUDA 12.8"
-            echo "    3) CUDA 13.1"
-            printf "  Choose [1-3, default=2]: "
+            echo "  No GPU auto-detected. Available builds:"
+            echo "    1) CUDA 12.4  (NVIDIA)"
+            echo "    2) CUDA 12.8  (NVIDIA)"
+            echo "    3) CUDA 13.1  (NVIDIA)"
+            echo "    4) ROCm 7.2   (AMD)"
+            printf "  Choose [1-4, default=2]: "
             if [ -r /dev/tty ]; then read -r _choice </dev/tty; else read -r _choice; fi
             case "$_choice" in
-                1) _cuda_tag="12.4" ;;
-                3) _cuda_tag="13.1" ;;
-                *) _cuda_tag="12.8" ;;
+                1) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-12.4-x64.tar.gz"; DEST="bin/cuda" ;;
+                3) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-13.1-x64.tar.gz"; DEST="bin/cuda" ;;
+                4) ASSET="llama-${RELEASE_TAG}-bin-linux-rocm-7.2-x64.tar.gz"; DEST="bin/rocm" ;;
+                *) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-12.8-x64.tar.gz"; DEST="bin/cuda" ;;
             esac
         fi
-
-        ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-${_cuda_tag}-x64.tar.gz"
-        DEST="bin/cuda"
         ;;
     *)
         err "Unsupported OS: $OS. Use setup.ps1 on Windows."

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -18,7 +18,7 @@ done
 
 # ── Find binary (search all known locations) ──
 BIN=""
-for _d in bin/mac bin/cuda llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
     [ -f "$DEMO_DIR/$_d/llama-cli" ] && BIN="$DEMO_DIR/$_d/llama-cli" && break
 done
 if [ -z "$BIN" ]; then

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -29,7 +29,7 @@ done
 
 # ── Find binary (search all known locations) ──
 BIN=""
-for _d in bin/mac bin/cuda llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
     [ -f "$DEMO_DIR/$_d/llama-server" ] && BIN="$DEMO_DIR/$_d/llama-server" && break
 done
 if [ -z "$BIN" ]; then

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -77,7 +77,7 @@ else
         [ -f "$_m" ] && _model="$DEMO_DIR/$_m" && break
     done
     _bin=""
-    for _d in bin/mac bin/cuda llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+    for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
         [ -f "$DEMO_DIR/$_d/llama-server" ] && _bin="$DEMO_DIR/$_d/llama-server" && break
     done
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -137,7 +137,6 @@ Write-Host "[OK] Dependencies installed." -ForegroundColor Green
 # ── 6. Detect GPU: NVIDIA (CUDA) or AMD (HIP) ──
 $GpuType = $null
 $CudaTag = "12.4"
-$NvidiaSmi = $null
 foreach ($p in @(
     (Get-Command nvidia-smi -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue),
     "$env:ProgramFiles\NVIDIA Corporation\NVSMI\nvidia-smi.exe",
@@ -148,10 +147,17 @@ foreach ($p in @(
             $out = & $p 2>&1 | Out-String
             if ($out -match 'CUDA Version:\s+(\d+)\.(\d+)') {
                 $major = [int]$Matches[1]; $minor = [int]$Matches[2]
-                if ($major -ge 13)                    { $CudaTag = "13.1" }
-                elseif ($major -eq 12 -and $minor -ge 4) { $CudaTag = "12.4" }
-                $NvidiaSmi = $p
-                $GpuType = "cuda"
+                if ($major -ge 13) {
+                    $CudaTag = "13.1"
+                    $GpuType = "cuda"
+                } elseif ($major -eq 12 -and $minor -ge 4) {
+                    $CudaTag = "12.4"
+                    $GpuType = "cuda"
+                } else {
+                    Write-Host "[WARN] Detected CUDA $major.$minor — no matching build available. Falling back to CUDA 12.4." -ForegroundColor Yellow
+                    $CudaTag = "12.4"
+                    $GpuType = "cuda"
+                }
                 break
             }
         } catch {}
@@ -161,7 +167,10 @@ if ($GpuType -eq "cuda") {
     Write-Host "[OK] NVIDIA GPU detected (CUDA $CudaTag)" -ForegroundColor Green
 } else {
     # Check for AMD HIP SDK
-    $HipPath = if ($env:HIP_PATH) { $env:HIP_PATH } else { $null }
+    $HipPath = $null
+    if ($env:HIP_PATH -and (Test-Path $env:HIP_PATH)) {
+        $HipPath = $env:HIP_PATH
+    }
     if (-not $HipPath) {
         # Check common install locations
         foreach ($candidate in @(
@@ -178,9 +187,9 @@ if ($GpuType -eq "cuda") {
     }
     if ($HipPath) {
         $GpuType = "hip"
-        Write-Host "[OK] AMD GPU detected (HIP SDK at $HipPath)" -ForegroundColor Green
+        Write-Host "[OK] AMD HIP/ROCm toolchain found at $HipPath" -ForegroundColor Green
     } else {
-        Write-Host "[WARN] No NVIDIA or AMD GPU detected. Binaries require a supported GPU." -ForegroundColor Yellow
+        Write-Host "[WARN] No NVIDIA or AMD GPU toolchain detected. Binaries require a supported GPU." -ForegroundColor Yellow
     }
 }
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -7,7 +7,8 @@ $PythonVersion = "3.11"
 $VenvDir = Join-Path $PSScriptRoot ".venv"
 $VenvPy  = Join-Path $VenvDir "Scripts\python.exe"
 
-$ReleaseTag = "prism-b8196-f5dda72"
+$ReleaseTag = "prism-b8201-ba7e817"
+$WinAssetTag = "prism-b1-ba7e817"                    # Windows builds use shortened tag
 $BaseUrl = "https://github.com/PrismML-Eng/llama.cpp/releases/download/$ReleaseTag"
 
 $BonsaiModel = if ($env:BONSAI_MODEL) { $env:BONSAI_MODEL } else { "8B" }
@@ -133,7 +134,8 @@ Write-Host "==> Installing Python dependencies ..." -ForegroundColor Cyan
 uv pip install --python $VenvPy huggingface-hub
 Write-Host "[OK] Dependencies installed." -ForegroundColor Green
 
-# ── 6. Detect GPU / CUDA version ──
+# ── 6. Detect GPU: NVIDIA (CUDA) or AMD (HIP) ──
+$GpuType = $null
 $CudaTag = "12.4"
 $NvidiaSmi = $null
 foreach ($p in @(
@@ -149,15 +151,37 @@ foreach ($p in @(
                 if ($major -ge 13)                    { $CudaTag = "13.1" }
                 elseif ($major -eq 12 -and $minor -ge 4) { $CudaTag = "12.4" }
                 $NvidiaSmi = $p
+                $GpuType = "cuda"
                 break
             }
         } catch {}
     }
 }
-if ($NvidiaSmi) {
+if ($GpuType -eq "cuda") {
     Write-Host "[OK] NVIDIA GPU detected (CUDA $CudaTag)" -ForegroundColor Green
 } else {
-    Write-Host "[WARN] No NVIDIA GPU detected. Binaries require a CUDA-capable GPU." -ForegroundColor Yellow
+    # Check for AMD HIP SDK
+    $HipPath = if ($env:HIP_PATH) { $env:HIP_PATH } else { $null }
+    if (-not $HipPath) {
+        # Check common install locations
+        foreach ($candidate in @(
+            "$env:ProgramFiles\AMD\ROCm\*\bin\hipcc.exe",
+            "$env:ProgramFiles\AMD\ROCm\bin\hipcc.exe"
+        )) {
+            $found = Get-Item $candidate -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($found) { $HipPath = $found.DirectoryName; break }
+        }
+    }
+    if (-not $HipPath) {
+        $hipCmd = Get-Command hipcc -ErrorAction SilentlyContinue
+        if ($hipCmd) { $HipPath = Split-Path $hipCmd.Source }
+    }
+    if ($HipPath) {
+        $GpuType = "hip"
+        Write-Host "[OK] AMD GPU detected (HIP SDK at $HipPath)" -ForegroundColor Green
+    } else {
+        Write-Host "[WARN] No NVIDIA or AMD GPU detected. Binaries require a supported GPU." -ForegroundColor Yellow
+    }
 }
 
 # ── 7. Download GGUF model ──
@@ -185,38 +209,58 @@ if ($BonsaiModel -eq "all") {
     Download-GgufModel $BonsaiModel
 }
 
-# ── 8. Download pre-built CUDA binaries ──
+# ── 8. Download pre-built binaries (CUDA or HIP) ──
 Write-Host "==> Downloading llama.cpp binaries ..." -ForegroundColor Cyan
-$BinDir = Join-Path $PSScriptRoot "bin\cuda"
-if (Test-Path "$BinDir\llama-cli.exe") {
-    Write-Host "[OK] Binaries already present." -ForegroundColor Green
-} else {
-    $Asset = "llama-prism-b1-f5dda72-bin-win-cuda-${CudaTag}-x64.zip"
-    $Url = "$BaseUrl/$Asset"
-    $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
+if ($GpuType -eq "hip") {
+    $BinDir = Join-Path $PSScriptRoot "bin\hip"
+    if (Test-Path "$BinDir\llama-cli.exe") {
+        Write-Host "[OK] Binaries already present." -ForegroundColor Green
+    } else {
+        $Asset = "llama-bin-win-hip-radeon-x64.zip"
+        $Url = "$BaseUrl/$Asset"
+        $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
 
-    Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
-    Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+        Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
+        Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
 
-    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-    Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
-    Remove-Item $TmpZip -Force
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+        Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
+        Remove-Item $TmpZip -Force
 
-    # Also download CUDA runtime DLLs
-    $DllAsset = "cudart-llama-bin-win-cuda-${CudaTag}-x64.zip"
-    $DllUrl = "$BaseUrl/$DllAsset"
-    $DllZip = [System.IO.Path]::GetTempFileName() + ".zip"
-
-    Write-Host "    Downloading CUDA runtime DLLs ..." -ForegroundColor Cyan
-    try {
-        Invoke-WebRequest -Uri $DllUrl -OutFile $DllZip -UseBasicParsing
-        Expand-Archive -Path $DllZip -DestinationPath $BinDir -Force
-        Remove-Item $DllZip -Force
-    } catch {
-        Write-Host "[WARN] Could not download CUDA DLLs. You may need to install CUDA toolkit." -ForegroundColor Yellow
+        Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
     }
+} else {
+    $BinDir = Join-Path $PSScriptRoot "bin\cuda"
+    if (Test-Path "$BinDir\llama-cli.exe") {
+        Write-Host "[OK] Binaries already present." -ForegroundColor Green
+    } else {
+        $Asset = "llama-${WinAssetTag}-bin-win-cuda-${CudaTag}-x64.zip"
+        $Url = "$BaseUrl/$Asset"
+        $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
 
-    Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
+        Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
+        Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+        Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
+        Remove-Item $TmpZip -Force
+
+        # Also download CUDA runtime DLLs
+        $DllAsset = "cudart-llama-bin-win-cuda-${CudaTag}-x64.zip"
+        $DllUrl = "$BaseUrl/$DllAsset"
+        $DllZip = [System.IO.Path]::GetTempFileName() + ".zip"
+
+        Write-Host "    Downloading CUDA runtime DLLs ..." -ForegroundColor Cyan
+        try {
+            Invoke-WebRequest -Uri $DllUrl -OutFile $DllZip -UseBasicParsing
+            Expand-Archive -Path $DllZip -DestinationPath $BinDir -Force
+            Remove-Item $DllZip -Force
+        } catch {
+            Write-Host "[WARN] Could not download CUDA DLLs. You may need to install CUDA toolkit." -ForegroundColor Yellow
+        }
+
+        Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
+    }
 }
 
 # ── Done ──

--- a/setup.sh
+++ b/setup.sh
@@ -160,13 +160,16 @@ case "$OS" in
         fi
         info "System packages OK."
 
-        # CUDA check (non-fatal)
+        # GPU toolkit check (non-fatal)
         if command -v nvcc >/dev/null 2>&1 || command -v nvidia-smi >/dev/null 2>&1; then
-            info "CUDA toolkit detected."
+            info "NVIDIA CUDA toolkit detected."
+        elif command -v rocminfo >/dev/null 2>&1 || command -v rocm-smi >/dev/null 2>&1 || command -v hipcc >/dev/null 2>&1; then
+            info "AMD ROCm toolkit detected."
         else
-            warn "CUDA toolkit not found. Pre-built CUDA binaries can still be downloaded,"
-            echo "       but building from source requires the CUDA toolkit."
-            echo "       Install from: https://developer.nvidia.com/cuda-downloads"
+            warn "No GPU toolkit found (CUDA or ROCm). Pre-built binaries can still be downloaded,"
+            echo "       but building from source requires a GPU toolkit."
+            echo "       NVIDIA: https://developer.nvidia.com/cuda-downloads"
+            echo "       AMD:    https://rocm.docs.amd.com/en/latest/deploy/linux/installer/install.html"
         fi
         ;;
 

--- a/setup.sh
+++ b/setup.sh
@@ -238,7 +238,7 @@ fi
 #  7. llama.cpp pre-built binaries
 # ────────────────────────────────────────────────────
 _has_binaries=false
-for _d in bin/mac bin/cuda; do
+for _d in bin/mac bin/cuda bin/rocm; do
     ls "$_d"/llama-* >/dev/null 2>&1 && _has_binaries=true && break
 done
 


### PR DESCRIPTION
Update to latest llama.cpp release (prism-b8201-ba7e817) and add AMD GPU support for Linux (ROCm) and Windows (HIP).

- Bump release tag and asset URLs across all download/setup scripts
- Auto-detect AMD ROCm on Linux (rocminfo/rocm-smi/hipcc) and HIP SDK on Windows
- Download ROCm 7.2 binaries to bin/rocm, HIP binaries to bin/hip
- Add bin/rocm and bin/hip to binary search paths in all run/server scripts
- Manual build menu now includes ROCm option when no GPU is auto-detected
- Fix Windows CUDA asset naming to use $WinAssetTag for the shortened build tag
- Validate $env:HIP_PATH before use, warn on unsupported CUDA versions