### PR TITLE
Fix PowerShell parser error caused by em dash on line 157

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -154,7 +154,7 @@ foreach ($p in @(
                     $CudaTag = "12.4"
                     $GpuType = "cuda"
                 } else {
-                    Write-Host "[WARN] Detected CUDA $major.$minor — no matching build available. Falling back to CUDA 12.4." -ForegroundColor Yellow
+                    Write-Host "[WARN] Detected CUDA $major.$minor - no matching build available. Falling back to CUDA 12.4." -ForegroundColor Yellow
                     $CudaTag = "12.4"
                     $GpuType = "cuda"
                 }


### PR DESCRIPTION
On Windows, the em dash (—) in the Write-Host string on line 157 causes 
a PowerShell parser error: "The string is missing the terminator". 

This is because PowerShell misreads the UTF-8 bytes of the em dash inside 
a string literal, causing it to lose track of where the string ends. This 
then cascades into a series of fake errors about missing brackets and 
try/catch blocks throughout the rest of the file, making setup.ps1 
completely unusable on Windows.

Fix: replaced the em dash with a plain hyphen (-).