### PR TITLE
Multi-backend support + new prism release

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,18 @@ Using this demo you can run Bonsai language models locally on Mac (Metal), Linux
 - **[llama.cpp](https://github.com/ggml-org/llama.cpp)** (GGUF) — C/C++, runs on Mac (Metal), Linux/Windows (CUDA, Vulkan, ROCm/HIP), and CPU.
 - **[MLX](https://github.com/ml-explore/mlx)** (MLX format) — Python, optimized for Apple Silicon.
 
-The required inference kernels are not yet available in upstream llama.cpp or MLX. Pre-built binaries and source code come from our forks:
+Q1_0 support for CPU, Metal, and Vulkan backends is already merged into upstream llama.cpp. Additional backends (optimized x86 CPU, CUDA, AMD) are pending. In the meantime, our fork provides a more complete set of backends in one place:
 - **llama.cpp:** [PrismML-Eng/llama.cpp](https://github.com/PrismML-Eng/llama.cpp) — [pre-built binaries](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8796-e2d6742)
 - **MLX:** [PrismML-Eng/mlx](https://github.com/PrismML-Eng/mlx) (branch `prism`)
 
-## News
-- llama.cpp CPU backend PR merged into main: https://github.com/ggml-org/llama.cpp/pull/21273
-- llama.cpp Metal backend PR pending: https://github.com/ggml-org/llama.cpp/pull/21528
-- MLX PR pending: https://github.com/ml-explore/mlx/pull/3161
+## Upstream Status
+| Backend | Status | PR |
+|---------|--------|----|
+| CPU (generic) | ✅ Merged | [#21273](https://github.com/ggml-org/llama.cpp/pull/21273) |
+| Metal | ✅ Merged | [#21528](https://github.com/ggml-org/llama.cpp/pull/21528) |
+| CPU (optimized x86) | ⏳ Pending | [#21636](https://github.com/ggml-org/llama.cpp/pull/21636) |
+| CUDA | ⏳ Pending | [#21629](https://github.com/ggml-org/llama.cpp/pull/21629) |
+| MLX | ⏳ Pending | [mlx#3161](https://github.com/ml-explore/mlx/pull/3161) |
 
 ## Models
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   <a href="https://discord.gg/prismml"><b>Discord</b></a>
 </p>
 
-Using this demo you can run Bonsai language models locally on Mac (Metal), Linux/Windows (CUDA).
+Using this demo you can run Bonsai language models locally on Mac (Metal), Linux/Windows (CUDA, Vulkan, ROCm), or CPU.
 
-- **[llama.cpp](https://github.com/ggml-org/llama.cpp)** (GGUF) — C/C++, runs on Mac (Metal), Linux/Windows (CUDA), and CPU.
+- **[llama.cpp](https://github.com/ggml-org/llama.cpp)** (GGUF) — C/C++, runs on Mac (Metal), Linux/Windows (CUDA, Vulkan, ROCm/HIP), and CPU.
 - **[MLX](https://github.com/ml-explore/mlx)** (MLX format) — Python, optimized for Apple Silicon.
 
 The required inference kernels are not yet available in upstream llama.cpp or MLX. Pre-built binaries and source code come from our forks:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using this demo you can run Bonsai language models locally on Mac (Metal), Linux
 - **[MLX](https://github.com/ml-explore/mlx)** (MLX format) — Python, optimized for Apple Silicon.
 
 The required inference kernels are not yet available in upstream llama.cpp or MLX. Pre-built binaries and source code come from our forks:
-- **llama.cpp:** [PrismML-Eng/llama.cpp](https://github.com/PrismML-Eng/llama.cpp) — [pre-built binaries](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8196-f5dda72)
+- **llama.cpp:** [PrismML-Eng/llama.cpp](https://github.com/PrismML-Eng/llama.cpp) — [pre-built binaries](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8796-e2d6742)
 - **MLX:** [PrismML-Eng/mlx](https://github.com/PrismML-Eng/mlx) (branch `prism`)
 
 ## News
@@ -94,7 +94,7 @@ The setup script handles everything for you, even on a fresh machine:
 2. **Installs [uv](https://docs.astral.sh/uv/)** — fast Python package manager (user-local, not global)
 3. **Creates a Python venv** and runs `uv sync` — installs cmake, ninja, huggingface-cli from `pyproject.toml`
 4. **Downloads models** from HuggingFace (needs `PRISM_HF_TOKEN` while repos are private)
-5. **Downloads pre-built binaries** from [GitHub Release](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8196-f5dda72) (or builds from source if you prefer)
+5. **Downloads pre-built binaries** from [GitHub Release](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8796-e2d6742) (or builds from source if you prefer)
 6. **Builds MLX from source** (macOS only) — clones our fork, then `uv sync --extra mlx` for the full ML stack
 
 Re-running `setup.sh` is safe — it skips already-completed steps.
@@ -170,13 +170,29 @@ uv pip install open-webui
 
 If you prefer to build llama.cpp from source instead of using pre-built binaries:
 
-### Mac
+### Mac (Apple Silicon — Metal)
 
 ```bash
 ./scripts/build_mac.sh
 ```
 
 Clones [PrismML-Eng/llama.cpp](https://github.com/PrismML-Eng/llama.cpp), builds with Metal, outputs to `bin/mac/`.
+
+### Mac (Intel — CPU only)
+
+```bash
+./scripts/build_mac.sh
+```
+
+The script auto-detects Intel vs Apple Silicon. On Intel Macs, it builds with `-DGGML_METAL=OFF` (CPU only). MLX is also skipped automatically since it requires Apple Silicon.
+
+### Linux (CPU only)
+
+```bash
+./scripts/build_cpu_linux.sh
+```
+
+Builds a CPU-only binary with no GPU dependencies. Works on both x64 and arm64. Outputs to `bin/cpu/`.
 
 ### Linux (CUDA)
 
@@ -185,6 +201,28 @@ Clones [PrismML-Eng/llama.cpp](https://github.com/PrismML-Eng/llama.cpp), builds
 ```
 
 Auto-detects CUDA version. Pass `--cuda-path /usr/local/cuda-12.8` to use a specific toolkit.
+
+### Linux (Vulkan)
+
+```bash
+# Install Vulkan SDK first (e.g. sudo apt install libvulkan-dev glslc)
+git clone -b prism https://github.com/PrismML-Eng/llama.cpp.git
+cd llama.cpp
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_VULKAN=ON
+cmake --build build -j$(nproc)
+# Binaries in build/bin/
+```
+
+### Linux (ROCm / AMD GPU)
+
+```bash
+# Requires ROCm toolkit (hipcc)
+git clone -b prism https://github.com/PrismML-Eng/llama.cpp.git
+cd llama.cpp
+cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_HIP=ON
+cmake --build build -j$(nproc)
+# Binaries in build/bin/
+```
 
 ### Windows (CUDA)
 
@@ -195,20 +233,42 @@ Auto-detects CUDA version. Pass `--cuda-path /usr/local/cuda-12.8` to use a spec
 Auto-detects CUDA toolkit. Pass `-CudaPath "C:\path\to\cuda"` to use a specific version.
 Requires Visual Studio Build Tools (or full Visual Studio) and CUDA toolkit.
 
+### Windows (CPU only)
+
+```powershell
+git clone -b prism https://github.com/PrismML-Eng/llama.cpp.git
+cd llama.cpp
+cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+# Binaries in build\bin\Release\
+```
+
+Requires Visual Studio Build Tools or full Visual Studio with C++ workload.
+
 ---
 
 ## llama.cpp Pre-built Binary Downloads
 
-All binaries are available from the [GitHub Release](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8196-f5dda72):
+All binaries are available from the [GitHub Release](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b8796-e2d6742):
 
-| Platform                |
-|-------------------------|
-| macOS Apple Silicon     |
-| Linux x64 (CUDA 12.4)  |
-| Linux x64 (CUDA 12.8)  |
-| Linux x64 (CUDA 13.1)  |
-| Windows x64 (CUDA 12.4) |
-| Windows x64 (CUDA 13.1) |
+| Platform                          |
+|-----------------------------------|
+| macOS Apple Silicon (arm64)       |
+| macOS Apple Silicon (KleidiAI)    |
+| macOS Intel (x64)                 |
+| Linux x64 (CPU)                   |
+| Linux arm64 (CPU)                 |
+| Linux x64 (CUDA 12.4)            |
+| Linux x64 (CUDA 12.8)            |
+| Linux x64 (Vulkan)               |
+| Linux arm64 (Vulkan)             |
+| Linux x64 (ROCm 7.2)             |
+| Windows x64 (CPU)                |
+| Windows arm64 (CPU)              |
+| Windows x64 (CUDA 12.4)          |
+| Windows x64 (Vulkan)             |
+| Windows x64 (HIP/ROCm)           |
+| iOS (XCFramework)                 |
 
 ---
 
@@ -233,6 +293,7 @@ Bonsai-demo/
 │   ├── start_mlx_server.sh         # MLX server (port 8081)
 │   ├── start_openwebui.sh          # Open WebUI + auto-starts backends
 │   ├── build_mac.sh                # Build llama.cpp for Mac
+│   ├── build_cpu_linux.sh          # Build llama.cpp for Linux (CPU only)
 │   ├── build_cuda_linux.sh         # Build llama.cpp for Linux CUDA
 │   └── build_cuda_windows.ps1      # Build llama.cpp for Windows CUDA
 ├── models/                         # ← downloaded by setup
@@ -244,8 +305,12 @@ Bonsai-demo/
 │   ├── Bonsai-4B-mlx/             # MLX 4B model (macOS)
 │   └── Bonsai-1.7B-mlx/           # MLX 1.7B model (macOS)
 ├── bin/                            # ← downloaded or built by setup
-│   ├── mac/                        # macOS binaries
-│   └── cuda/                       # CUDA binaries
+│   ├── mac/                        # macOS binaries (Metal or CPU)
+│   ├── cuda/                       # CUDA binaries (Linux/Windows)
+│   ├── cpu/                        # CPU-only binaries (Linux/Windows)
+│   ├── vulkan/                     # Vulkan binaries
+│   ├── rocm/                       # ROCm binaries (AMD Linux)
+│   └── hip/                        # HIP binaries (AMD Windows)
 ├── mlx/                            # ← cloned by setup (macOS)
 └── .venv/                          # ← created by setup
 ```

--- a/scripts/build_cpu_linux.sh
+++ b/scripts/build_cpu_linux.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Build llama.cpp for Linux (CPU only — no GPU dependencies).
+# Prerequisites: cmake, a C/C++ compiler (gcc/g++ or clang)
+# Usage: ./scripts/build_cpu_linux.sh [path_to_llama_cpp_repo]
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/common.sh"
+DEMO_DIR="$(resolve_demo_dir)"
+cd "$DEMO_DIR"
+
+REPO_DIR="${1:-./llama.cpp}"
+TARGETS="llama-completion llama-cli llama-server llama-quantize llama-perplexity"
+DEST="./bin/cpu"
+
+# ── Clone if needed ──
+if [ ! -d "$REPO_DIR" ]; then
+    step "Cloning PrismML-Eng/llama.cpp (prism branch) ..."
+    git clone -b prism https://github.com/PrismML-Eng/llama.cpp.git "$REPO_DIR"
+    info "Cloned to $REPO_DIR"
+fi
+
+# ── Remove old binaries if present ──
+if [ -d "$DEST" ]; then
+    step "Removing previously built binaries in $DEST/ ..."
+    rm -rf "$DEST"
+fi
+
+# ── Build ──
+step "Building llama.cpp for Linux (CPU only) ..."
+echo "  Repo:    $REPO_DIR"
+echo "  Targets: $TARGETS"
+
+cd "$REPO_DIR"
+cmake -B build-cpu \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DGGML_NATIVE=ON \
+    -DGGML_CUDA=OFF \
+    -DGGML_METAL=OFF \
+    -DGGML_VULKAN=OFF \
+    -DGGML_HIP=OFF
+cmake --build build-cpu --target $TARGETS -j$(nproc)
+cd - > /dev/null
+
+# ── Copy binaries ──
+step "Installing binaries to $DEST/ ..."
+mkdir -p "$DEST"
+
+for _bin in $TARGETS; do
+    if [ -f "$REPO_DIR/build-cpu/bin/$_bin" ]; then
+        cp "$REPO_DIR/build-cpu/bin/$_bin" "$DEST/"
+        info "$_bin"
+    fi
+done
+
+# Copy shared libs if any
+for _lib in "$REPO_DIR"/build-cpu/bin/lib*.so*; do
+    [ -f "$_lib" ] && cp "$_lib" "$DEST/" || true
+done
+
+# ── Smoke test ──
+step "Verifying build ..."
+if "$DEST/llama-cli" --version >/dev/null 2>&1 || "$DEST/llama-cli" --help >/dev/null 2>&1; then
+    info "Build verified — llama-cli runs."
+else
+    warn "llama-cli did not respond to --version or --help (may still work)."
+fi
+
+echo ""
+info "Build complete! CPU binaries are in $DEST/"
+echo ""
+echo "  Run:"
+echo "    ./scripts/run_llama.sh -p \"Hello!\""
+echo "    ./scripts/start_llama_server.sh"
+echo ""

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Build llama.cpp for Mac (Apple Silicon / Metal)
+# Build llama.cpp for Mac — Apple Silicon (Metal) or Intel (CPU only).
 # Prerequisites: Xcode command-line tools, cmake
 # Usage: ./scripts/build_mac.sh [path_to_llama_cpp_repo]
 set -e
@@ -26,21 +26,42 @@ if [ -d "$DEST" ]; then
     rm -rf "$DEST"
 fi
 
-# ── Build (native-optimized for this Mac) ──
-step "Building llama.cpp for Mac (Apple Silicon / Metal) ..."
+# ── Build (native for this Mac) ──
+MAC_ARCH="$(uname -m)"
 echo "  Repo:    $REPO_DIR"
 echo "  Targets: $TARGETS"
+echo "  Arch:    $MAC_ARCH"
 
 cd "$REPO_DIR"
-cmake -B build-mac \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_OSX_ARCHITECTURES=arm64 \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
-    -DGGML_METAL=ON \
-    -DGGML_METAL_EMBED_LIBRARY=ON \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DGGML_STATIC=ON \
-    -DLLAMA_OPENSSL=OFF
+case "$MAC_ARCH" in
+    arm64)
+        step "Building llama.cpp (Apple Silicon + Metal) ..."
+        cmake -B build-mac \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 \
+            -DGGML_METAL=ON \
+            -DGGML_METAL_EMBED_LIBRARY=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_STATIC=ON \
+            -DLLAMA_OPENSSL=OFF
+        ;;
+    x86_64)
+        step "Building llama.cpp (Intel macOS, CPU only — no Metal) ..."
+        cmake -B build-mac \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+            -DGGML_METAL=OFF \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DGGML_STATIC=ON \
+            -DLLAMA_OPENSSL=OFF
+        ;;
+    *)
+        err "Unsupported Mac architecture: $MAC_ARCH"
+        exit 1
+        ;;
+esac
 
 cmake --build build-mac --target $TARGETS -j$(sysctl -n hw.logicalcpu)
 cd - > /dev/null

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -80,6 +80,27 @@ download() {
 
 CTX_SIZE_DEFAULT=0
 
+# GPU layer offload: Intel macOS has no Metal, so use 0 (CPU only).
+# Everything else (Apple Silicon, CUDA, ROCm, Vulkan) gets full offload.
+bonsai_llama_ngl() {
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+        echo 0
+    else
+        echo 99
+    fi
+}
+
+# MLX is Apple Silicon only; skip on Intel Mac or when BONSAI_SKIP_MLX=1.
+bonsai_should_skip_mlx() {
+    case "${BONSAI_SKIP_MLX:-}" in
+        1|true|yes) return 0 ;;
+        0|false|no) return 1 ;;
+        *)
+            [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ] && return 0
+            return 1 ;;
+    esac
+}
+
 get_context_size_fallback() {
     if [ "$(uname -s)" = "Darwin" ]; then
         _mem_gb=$(( $(sysctl -n hw.memsize) / 1073741824 ))

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -80,13 +80,23 @@ download() {
 
 CTX_SIZE_DEFAULT=0
 
-# GPU layer offload: Intel macOS has no Metal, so use 0 (CPU only).
-# Everything else (Apple Silicon, CUDA, ROCm, Vulkan) gets full offload.
+# GPU layer offload: 99 = offload all layers to GPU, 0 = CPU only.
+# Override with BONSAI_NGL env var if needed.
 bonsai_llama_ngl() {
-    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
-        echo 0
+    if [ -n "${BONSAI_NGL:-}" ]; then
+        echo "$BONSAI_NGL"
+    elif [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+        echo 0  # Intel Mac — no Metal
+    elif command -v nvidia-smi >/dev/null 2>&1 || command -v nvcc >/dev/null 2>&1; then
+        echo 99  # CUDA
+    elif command -v rocminfo >/dev/null 2>&1 || command -v hipcc >/dev/null 2>&1; then
+        echo 99  # ROCm/HIP
+    elif command -v vulkaninfo >/dev/null 2>&1; then
+        echo 99  # Vulkan
+    elif [ "$(uname -s)" = "Darwin" ]; then
+        echo 99  # Apple Silicon — Metal
     else
-        echo 99
+        echo 0   # CPU only
     fi
 }
 

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -31,7 +31,7 @@ case "$OS" in
         case "$_arch" in
             x86_64)  _arch_tag="x64" ;;
             aarch64) _arch_tag="arm64" ;;
-            *)       _arch_tag="x64" ;;
+            *)       err "Unsupported Linux architecture: $_arch (supported: x86_64, aarch64)"; exit 1 ;;
         esac
 
         # ── Detect GPU: NVIDIA (CUDA), AMD (ROCm), or Vulkan ──

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -53,25 +53,28 @@ case "$OS" in
             _gpu_type="vulkan"
         fi
 
-        if [ "$_gpu_type" = "cuda" ]; then
-            if [ "$_arch_tag" != "x64" ]; then
-                warn "CUDA detected but no CUDA build available for $_arch_tag — falling back to CPU."
-                _gpu_type=""
-            else
-                _major="${_cuda_ver%%.*}"
-                _minor="${_cuda_ver#*.}"
-                if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
-                    _cuda_tag="12.8"
-                elif [ "$_major" -eq 12 ]; then
-                    _cuda_tag="12.4"
-                else
-                    warn "Detected CUDA $_cuda_ver — no matching build available, falling back to CUDA 12.4"
-                    _cuda_tag="12.4"
-                fi
-                info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"
-            fi
+        # Guard CUDA/ROCm to x64 only (no arm64 builds available)
+        if [ "$_arch_tag" != "x64" ] && { [ "$_gpu_type" = "cuda" ] || [ "$_gpu_type" = "rocm" ]; }; then
+            warn "$_gpu_type detected but no $_gpu_type build available for $_arch_tag — falling back."
+            _gpu_type=""
         fi
 
+        # Resolve CUDA version tag
+        if [ "$_gpu_type" = "cuda" ]; then
+            _major="${_cuda_ver%%.*}"
+            _minor="${_cuda_ver#*.}"
+            if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
+                _cuda_tag="12.8"
+            elif [ "$_major" -eq 12 ]; then
+                _cuda_tag="12.4"
+            else
+                warn "Detected CUDA $_cuda_ver — no matching build, falling back to CUDA 12.4"
+                _cuda_tag="12.4"
+            fi
+            info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"
+        fi
+
+        # Select asset
         if [ "$_gpu_type" = "cuda" ]; then
             ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-${_cuda_tag}-x64.tar.gz"
             DEST="bin/cuda"

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -54,17 +54,25 @@ case "$OS" in
         fi
 
         if [ "$_gpu_type" = "cuda" ]; then
-            _major="${_cuda_ver%%.*}"
-            _minor="${_cuda_ver#*.}"
-            if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
-                _cuda_tag="12.8"
-            elif [ "$_major" -eq 12 ]; then
-                _cuda_tag="12.4"
+            if [ "$_arch_tag" != "x64" ]; then
+                warn "CUDA detected but no CUDA build available for $_arch_tag — falling back to CPU."
+                _gpu_type=""
             else
-                warn "Detected CUDA $_cuda_ver — no matching build available, falling back to CUDA 12.4"
-                _cuda_tag="12.4"
+                _major="${_cuda_ver%%.*}"
+                _minor="${_cuda_ver#*.}"
+                if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
+                    _cuda_tag="12.8"
+                elif [ "$_major" -eq 12 ]; then
+                    _cuda_tag="12.4"
+                else
+                    warn "Detected CUDA $_cuda_ver — no matching build available, falling back to CUDA 12.4"
+                    _cuda_tag="12.4"
+                fi
+                info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"
             fi
-            info "Detected CUDA $_cuda_ver → using build for CUDA $_cuda_tag"
+        fi
+
+        if [ "$_gpu_type" = "cuda" ]; then
             ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-${_cuda_tag}-x64.tar.gz"
             DEST="bin/cuda"
         elif [ "$_gpu_type" = "rocm" ]; then

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -10,18 +10,31 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 
-RELEASE_TAG="prism-b8201-ba7e817"
+RELEASE_TAG="prism-b8796-e2d6742"
 BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TAG"
 
 OS="$(uname -s)"
 
 case "$OS" in
     Darwin)
-        ASSET="llama-${RELEASE_TAG}-bin-macos-arm64.tar.gz"
+        _arch="$(uname -m)"
+        if [ "$_arch" = "arm64" ]; then
+            ASSET="llama-${RELEASE_TAG}-bin-macos-arm64.tar.gz"
+        else
+            ASSET="llama-${RELEASE_TAG}-bin-macos-x64.tar.gz"
+        fi
         DEST="bin/mac"
         ;;
     Linux)
-        # ── Detect GPU: NVIDIA (CUDA) or AMD (ROCm) ──
+        # ── Detect architecture ──
+        _arch="$(uname -m)"
+        case "$_arch" in
+            x86_64)  _arch_tag="x64" ;;
+            aarch64) _arch_tag="arm64" ;;
+            *)       _arch_tag="x64" ;;
+        esac
+
+        # ── Detect GPU: NVIDIA (CUDA), AMD (ROCm), or Vulkan ──
         _gpu_type=""
         _cuda_ver=""
 
@@ -36,14 +49,14 @@ case "$OS" in
             _gpu_type="cuda"
         elif command -v rocminfo >/dev/null 2>&1 || command -v rocm-smi >/dev/null 2>&1 || command -v hipcc >/dev/null 2>&1; then
             _gpu_type="rocm"
+        elif command -v vulkaninfo >/dev/null 2>&1; then
+            _gpu_type="vulkan"
         fi
 
         if [ "$_gpu_type" = "cuda" ]; then
             _major="${_cuda_ver%%.*}"
             _minor="${_cuda_ver#*.}"
-            if [ "$_major" -ge 13 ]; then
-                _cuda_tag="13.1"
-            elif [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; then
+            if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
                 _cuda_tag="12.8"
             elif [ "$_major" -eq 12 ]; then
                 _cuda_tag="12.4"
@@ -56,23 +69,16 @@ case "$OS" in
             DEST="bin/cuda"
         elif [ "$_gpu_type" = "rocm" ]; then
             info "Detected AMD ROCm → using ROCm 7.2 build"
-            ASSET="llama-${RELEASE_TAG}-bin-linux-rocm-7.2-x64.tar.gz"
+            ASSET="llama-${RELEASE_TAG}-bin-ubuntu-rocm-7.2-x64.tar.gz"
             DEST="bin/rocm"
+        elif [ "$_gpu_type" = "vulkan" ]; then
+            info "Detected Vulkan → using Vulkan build"
+            ASSET="llama-${RELEASE_TAG}-bin-ubuntu-vulkan-${_arch_tag}.tar.gz"
+            DEST="bin/vulkan"
         else
-            echo ""
-            echo "  No GPU auto-detected. Available builds:"
-            echo "    1) CUDA 12.4  (NVIDIA)"
-            echo "    2) CUDA 12.8  (NVIDIA)"
-            echo "    3) CUDA 13.1  (NVIDIA)"
-            echo "    4) ROCm 7.2   (AMD)"
-            printf "  Choose [1-4, default=2]: "
-            if [ -r /dev/tty ]; then read -r _choice </dev/tty; else read -r _choice; fi
-            case "$_choice" in
-                1) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-12.4-x64.tar.gz"; DEST="bin/cuda" ;;
-                3) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-13.1-x64.tar.gz"; DEST="bin/cuda" ;;
-                4) ASSET="llama-${RELEASE_TAG}-bin-linux-rocm-7.2-x64.tar.gz"; DEST="bin/rocm" ;;
-                *) ASSET="llama-${RELEASE_TAG}-bin-linux-cuda-12.8-x64.tar.gz"; DEST="bin/cuda" ;;
-            esac
+            info "No GPU detected → using CPU build ($_arch_tag)"
+            ASSET="llama-${RELEASE_TAG}-bin-ubuntu-${_arch_tag}.tar.gz"
+            DEST="bin/cpu"
         fi
         ;;
     *)

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -61,8 +61,8 @@ download_size() {
         info "GGUF ${_size} downloaded to ${_gguf_dir}/"
     fi
 
-    # MLX (macOS only)
-    if [ "$(uname -s)" = "Darwin" ]; then
+    # MLX (macOS Apple Silicon only; skipped on Intel or when BONSAI_SKIP_MLX=1)
+    if [ "$(uname -s)" = "Darwin" ] && ! bonsai_should_skip_mlx; then
         if [ -d "$_mlx_dir" ] && [ -f "$_mlx_dir/config.json" ]; then
             info "MLX ${_size} already present in ${_mlx_dir}/"
         else
@@ -79,6 +79,8 @@ download_size "$BONSAI_MODEL"
 
 if [ "$(uname -s)" != "Darwin" ]; then
     info "Skipping MLX models (macOS only)."
+elif bonsai_should_skip_mlx; then
+    info "Skipping MLX weights (Intel macOS or BONSAI_SKIP_MLX=1)."
 fi
 
 echo ""

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -18,7 +18,7 @@ done
 
 # ── Find binary (search all known locations) ──
 BIN=""
-for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
     [ -f "$DEMO_DIR/$_d/llama-cli" ] && BIN="$DEMO_DIR/$_d/llama-cli" && break
 done
 if [ -z "$BIN" ]; then
@@ -30,11 +30,13 @@ fi
 BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"
 export LD_LIBRARY_PATH="$BIN_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
+NGL=$(bonsai_llama_ngl)
+
 info "Model:  $MODEL"
 info "Binary: $BIN"
-info "Using -c 0 (auto-fit to available memory)"
+info "Using -ngl $NGL, -c 0 (auto-fit to available memory)"
 
-"$BIN" -m "$MODEL" -ngl 99 -c "$CTX_SIZE_DEFAULT" --log-disable \
+"$BIN" -m "$MODEL" -ngl "$NGL" -c "$CTX_SIZE_DEFAULT" --log-disable \
     --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
     --reasoning-budget 0 --reasoning-format none \
     --chat-template-kwargs '{"enable_thinking": false}' \
@@ -42,7 +44,7 @@ info "Using -c 0 (auto-fit to available memory)"
 || {
     CTX_SIZE=$(get_context_size_fallback)
     warn "Auto-fit not supported, falling back to -c $CTX_SIZE"
-    "$BIN" -m "$MODEL" -ngl 99 -c "$CTX_SIZE" --log-disable \
+    "$BIN" -m "$MODEL" -ngl "$NGL" -c "$CTX_SIZE" --log-disable \
         --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
         --reasoning-budget 0 --reasoning-format none \
         --chat-template-kwargs '{"enable_thinking": false}' \

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -29,7 +29,7 @@ done
 
 # ── Find binary (search all known locations) ──
 BIN=""
-for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
     [ -f "$DEMO_DIR/$_d/llama-server" ] && BIN="$DEMO_DIR/$_d/llama-server" && break
 done
 if [ -z "$BIN" ]; then
@@ -51,7 +51,9 @@ echo "  API:  http://localhost:$PORT/v1/chat/completions"
 echo "  Press Ctrl+C to stop."
 echo ""
 
-exec "$BIN" -m "$MODEL" --host "$HOST" --port "$PORT" -ngl 99 -c "$CTX_SIZE_DEFAULT" \
+NGL=$(bonsai_llama_ngl)
+
+exec "$BIN" -m "$MODEL" --host "$HOST" --port "$PORT" -ngl "$NGL" -c "$CTX_SIZE_DEFAULT" \
     --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
     --reasoning-budget 0 --reasoning-format none \
     --chat-template-kwargs '{"enable_thinking": false}' \

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -77,7 +77,7 @@ else
         [ -f "$_m" ] && _model="$DEMO_DIR/$_m" && break
     done
     _bin=""
-    for _d in bin/mac bin/cuda bin/rocm bin/hip llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+    for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
         [ -f "$DEMO_DIR/$_d/llama-server" ] && _bin="$DEMO_DIR/$_d/llama-server" && break
     done
 
@@ -85,7 +85,8 @@ else
         step "Starting llama-server on port $LLAMA_PORT ..."
         _bin_dir="$(cd "$(dirname "$_bin")" && pwd)"
         LD_LIBRARY_PATH="$_bin_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-        "$_bin" -m "$_model" --host 0.0.0.0 --port "$LLAMA_PORT" -ngl 99 -c "$CTX_SIZE_DEFAULT" \
+        _ngl=$(bonsai_llama_ngl)
+        "$_bin" -m "$_model" --host 0.0.0.0 --port "$LLAMA_PORT" -ngl "$_ngl" -c "$CTX_SIZE_DEFAULT" \
             --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
             --reasoning-budget 0 --reasoning-format none \
             --chat-template-kwargs '{"enable_thinking": false}' \

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -84,8 +84,8 @@ else
     if [ -n "$_model" ] && [ -n "$_bin" ]; then
         step "Starting llama-server on port $LLAMA_PORT ..."
         _bin_dir="$(cd "$(dirname "$_bin")" && pwd)"
-        LD_LIBRARY_PATH="$_bin_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
         _ngl=$(bonsai_llama_ngl)
+        LD_LIBRARY_PATH="$_bin_dir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
         "$_bin" -m "$_model" --host 0.0.0.0 --port "$LLAMA_PORT" -ngl "$_ngl" -c "$CTX_SIZE_DEFAULT" \
             --temp 0.5 --top-p 0.85 --top-k 20 --min-p 0 \
             --reasoning-budget 0 --reasoning-format none \

--- a/setup.ps1
+++ b/setup.ps1
@@ -242,6 +242,12 @@ function Download-Binary($Asset, $BinDir) {
 # Detect Windows architecture
 $WinArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" } else { "x64" }
 
+# GPU backends only have x64 builds — fall back to CPU on ARM64
+if ($WinArch -eq "arm64" -and $GpuType -ne "cpu") {
+    Write-Host "[WARN] $GpuType detected but no ARM64 build available — falling back to CPU." -ForegroundColor Yellow
+    $GpuType = "cpu"
+}
+
 if ($GpuType -eq "hip") {
     $BinDir = Join-Path $PSScriptRoot "bin\hip"
     Download-Binary "llama-bin-win-hip-radeon-x64.zip" $BinDir

--- a/setup.ps1
+++ b/setup.ps1
@@ -147,16 +147,11 @@ foreach ($p in @(
             $out = & $p 2>&1 | Out-String
             if ($out -match 'CUDA Version:\s+(\d+)\.(\d+)') {
                 $major = [int]$Matches[1]; $minor = [int]$Matches[2]
-                if ($major -ge 13) {
-                    $CudaTag = "13.1"
-                    $GpuType = "cuda"
-                } elseif ($major -eq 12 -and $minor -ge 4) {
-                    $CudaTag = "12.4"
-                    $GpuType = "cuda"
-                } else {
-                    Write-Host "[WARN] Detected CUDA $major.$minor - no matching build available. Falling back to CUDA 12.4." -ForegroundColor Yellow
-                    $CudaTag = "12.4"
-                    $GpuType = "cuda"
+                # We only ship Windows CUDA 12.4 — any CUDA version >= 12.4 is compatible
+                $CudaTag = "12.4"
+                $GpuType = "cuda"
+                if ($major -lt 12 -or ($major -eq 12 -and $minor -lt 4)) {
+                    Write-Host "[WARN] Detected CUDA $major.$minor — older than 12.4, may not be compatible." -ForegroundColor Yellow
                 }
                 break
             }

--- a/setup.ps1
+++ b/setup.ps1
@@ -7,8 +7,8 @@ $PythonVersion = "3.11"
 $VenvDir = Join-Path $PSScriptRoot ".venv"
 $VenvPy  = Join-Path $VenvDir "Scripts\python.exe"
 
-$ReleaseTag = "prism-b8201-ba7e817"
-$WinAssetTag = "prism-b1-ba7e817"                    # Windows builds use shortened tag
+$ReleaseTag = "prism-b8796-e2d6742"
+$WinAssetTag = "prism-b1-e2d6742"                    # Windows builds use shortened tag
 $BaseUrl = "https://github.com/PrismML-Eng/llama.cpp/releases/download/$ReleaseTag"
 
 $BonsaiModel = if ($env:BONSAI_MODEL) { $env:BONSAI_MODEL } else { "8B" }
@@ -189,7 +189,8 @@ if ($GpuType -eq "cuda") {
         $GpuType = "hip"
         Write-Host "[OK] AMD HIP/ROCm toolchain found at $HipPath" -ForegroundColor Green
     } else {
-        Write-Host "[WARN] No NVIDIA or AMD GPU toolchain detected. Binaries require a supported GPU." -ForegroundColor Yellow
+        $GpuType = "cpu"
+        Write-Host "[INFO] No NVIDIA or AMD GPU toolchain detected. Will use CPU build." -ForegroundColor Yellow
     }
 }
 
@@ -218,58 +219,51 @@ if ($BonsaiModel -eq "all") {
     Download-GgufModel $BonsaiModel
 }
 
-# ── 8. Download pre-built binaries (CUDA or HIP) ──
+# ── 8. Download pre-built binaries ──
 Write-Host "==> Downloading llama.cpp binaries ..." -ForegroundColor Cyan
+
+function Download-Binary($Asset, $BinDir) {
+    if (Test-Path "$BinDir\llama-cli.exe") {
+        Write-Host "[OK] Binaries already present in $BinDir." -ForegroundColor Green
+        return
+    }
+    $Url = "$BaseUrl/$Asset"
+    $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
+
+    Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
+    Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+
+    New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+    Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
+    Remove-Item $TmpZip -Force
+
+    Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
+}
+
 if ($GpuType -eq "hip") {
     $BinDir = Join-Path $PSScriptRoot "bin\hip"
-    if (Test-Path "$BinDir\llama-cli.exe") {
-        Write-Host "[OK] Binaries already present." -ForegroundColor Green
-    } else {
-        $Asset = "llama-bin-win-hip-radeon-x64.zip"
-        $Url = "$BaseUrl/$Asset"
-        $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
+    Download-Binary "llama-bin-win-hip-radeon-x64.zip" $BinDir
+} elseif ($GpuType -eq "cuda") {
+    $BinDir = Join-Path $PSScriptRoot "bin\cuda"
+    Download-Binary "llama-${WinAssetTag}-bin-win-cuda-${CudaTag}-x64.zip" $BinDir
 
-        Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
-        Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
+    # Also download CUDA runtime DLLs
+    $DllAsset = "cudart-llama-bin-win-cuda-${CudaTag}-x64.zip"
+    $DllUrl = "$BaseUrl/$DllAsset"
+    $DllZip = [System.IO.Path]::GetTempFileName() + ".zip"
 
-        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-        Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
-        Remove-Item $TmpZip -Force
-
-        Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
+    Write-Host "    Downloading CUDA runtime DLLs ..." -ForegroundColor Cyan
+    try {
+        Invoke-WebRequest -Uri $DllUrl -OutFile $DllZip -UseBasicParsing
+        Expand-Archive -Path $DllZip -DestinationPath $BinDir -Force
+        Remove-Item $DllZip -Force
+    } catch {
+        Write-Host "[WARN] Could not download CUDA DLLs. You may need to install CUDA toolkit." -ForegroundColor Yellow
     }
 } else {
-    $BinDir = Join-Path $PSScriptRoot "bin\cuda"
-    if (Test-Path "$BinDir\llama-cli.exe") {
-        Write-Host "[OK] Binaries already present." -ForegroundColor Green
-    } else {
-        $Asset = "llama-${WinAssetTag}-bin-win-cuda-${CudaTag}-x64.zip"
-        $Url = "$BaseUrl/$Asset"
-        $TmpZip = [System.IO.Path]::GetTempFileName() + ".zip"
-
-        Write-Host "    Downloading $Asset ..." -ForegroundColor Cyan
-        Invoke-WebRequest -Uri $Url -OutFile $TmpZip -UseBasicParsing
-
-        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
-        Expand-Archive -Path $TmpZip -DestinationPath $BinDir -Force
-        Remove-Item $TmpZip -Force
-
-        # Also download CUDA runtime DLLs
-        $DllAsset = "cudart-llama-bin-win-cuda-${CudaTag}-x64.zip"
-        $DllUrl = "$BaseUrl/$DllAsset"
-        $DllZip = [System.IO.Path]::GetTempFileName() + ".zip"
-
-        Write-Host "    Downloading CUDA runtime DLLs ..." -ForegroundColor Cyan
-        try {
-            Invoke-WebRequest -Uri $DllUrl -OutFile $DllZip -UseBasicParsing
-            Expand-Archive -Path $DllZip -DestinationPath $BinDir -Force
-            Remove-Item $DllZip -Force
-        } catch {
-            Write-Host "[WARN] Could not download CUDA DLLs. You may need to install CUDA toolkit." -ForegroundColor Yellow
-        }
-
-        Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
-    }
+    # CPU fallback
+    $BinDir = Join-Path $PSScriptRoot "bin\cpu"
+    Download-Binary "llama-bin-win-cpu-x64.zip" $BinDir
 }
 
 # ── Done ──

--- a/setup.ps1
+++ b/setup.ps1
@@ -147,11 +147,12 @@ foreach ($p in @(
             $out = & $p 2>&1 | Out-String
             if ($out -match 'CUDA Version:\s+(\d+)\.(\d+)') {
                 $major = [int]$Matches[1]; $minor = [int]$Matches[2]
-                # We only ship Windows CUDA 12.4 — any CUDA version >= 12.4 is compatible
-                $CudaTag = "12.4"
-                $GpuType = "cuda"
-                if ($major -lt 12 -or ($major -eq 12 -and $minor -lt 4)) {
-                    Write-Host "[WARN] Detected CUDA $major.$minor — older than 12.4, may not be compatible." -ForegroundColor Yellow
+                if ($major -gt 12 -or ($major -eq 12 -and $minor -ge 4)) {
+                    $CudaTag = "12.4"
+                    $GpuType = "cuda"
+                } else {
+                    Write-Host "[WARN] Detected CUDA $major.$minor — older than 12.4, falling back to CPU." -ForegroundColor Yellow
+                    $GpuType = "cpu"
                 }
                 break
             }
@@ -183,9 +184,12 @@ if ($GpuType -eq "cuda") {
     if ($HipPath) {
         $GpuType = "hip"
         Write-Host "[OK] AMD HIP/ROCm toolchain found at $HipPath" -ForegroundColor Green
+    } elseif (Get-Command vulkaninfo -ErrorAction SilentlyContinue) {
+        $GpuType = "vulkan"
+        Write-Host "[OK] Vulkan SDK detected." -ForegroundColor Green
     } else {
         $GpuType = "cpu"
-        Write-Host "[INFO] No NVIDIA or AMD GPU toolchain detected. Will use CPU build." -ForegroundColor Yellow
+        Write-Host "[INFO] No GPU toolchain detected. Will use CPU build." -ForegroundColor Yellow
     }
 }
 
@@ -235,6 +239,9 @@ function Download-Binary($Asset, $BinDir) {
     Write-Host "[OK] Binaries installed to $BinDir" -ForegroundColor Green
 }
 
+# Detect Windows architecture
+$WinArch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "arm64" } else { "x64" }
+
 if ($GpuType -eq "hip") {
     $BinDir = Join-Path $PSScriptRoot "bin\hip"
     Download-Binary "llama-bin-win-hip-radeon-x64.zip" $BinDir
@@ -255,10 +262,13 @@ if ($GpuType -eq "hip") {
     } catch {
         Write-Host "[WARN] Could not download CUDA DLLs. You may need to install CUDA toolkit." -ForegroundColor Yellow
     }
+} elseif ($GpuType -eq "vulkan") {
+    $BinDir = Join-Path $PSScriptRoot "bin\vulkan"
+    Download-Binary "llama-bin-win-vulkan-x64.zip" $BinDir
 } else {
-    # CPU fallback
+    # CPU fallback (arch-aware)
     $BinDir = Join-Path $PSScriptRoot "bin\cpu"
-    Download-Binary "llama-bin-win-cpu-x64.zip" $BinDir
+    Download-Binary "llama-bin-win-cpu-${WinArch}.zip" $BinDir
 }
 
 # ── Done ──

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,7 @@ set -e
 # ── Resolve paths ──
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
+. "$SCRIPT_DIR/scripts/common.sh"
 
 VENV_DIR="$SCRIPT_DIR/.venv"
 VENV_PY="$VENV_DIR/bin/python"

--- a/setup.sh
+++ b/setup.sh
@@ -241,7 +241,7 @@ fi
 #  7. llama.cpp pre-built binaries
 # ────────────────────────────────────────────────────
 _has_binaries=false
-for _d in bin/mac bin/cuda bin/rocm; do
+for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu; do
     ls "$_d"/llama-* >/dev/null 2>&1 && _has_binaries=true && break
 done
 
@@ -254,12 +254,16 @@ fi
 chmod +x "$SCRIPT_DIR"/scripts/*.sh 2>/dev/null || true
 
 echo ""
-info "llama.cpp is ready! You can start using it now while MLX builds."
+if bonsai_should_skip_mlx; then
+    info "llama.cpp is ready! (MLX skipped — Intel Mac or BONSAI_SKIP_MLX=1; use ./scripts/run_llama.sh)"
+else
+    info "llama.cpp is ready! You can start using it now while MLX builds."
+fi
 
 # ────────────────────────────────────────────────────
-#  8. MLX (macOS only) — clone and build from source
+#  8. MLX (macOS only, Apple Silicon) — clone and build from source
 # ────────────────────────────────────────────────────
-if [ "$OS" = "Darwin" ]; then
+if [ "$OS" = "Darwin" ] && ! bonsai_should_skip_mlx; then
     step "Setting up MLX (Apple Silicon) ..."
 
     # MLX builds Metal GPU kernels, which requires the full Xcode app *and*

--- a/setup.sh
+++ b/setup.sh
@@ -255,10 +255,12 @@ fi
 chmod +x "$SCRIPT_DIR"/scripts/*.sh 2>/dev/null || true
 
 echo ""
-if bonsai_should_skip_mlx; then
+if [ "$OS" = "Darwin" ] && ! bonsai_should_skip_mlx; then
+    info "llama.cpp is ready! You can start using it now while MLX builds."
+elif [ "$OS" = "Darwin" ]; then
     info "llama.cpp is ready! (MLX skipped — Intel Mac or BONSAI_SKIP_MLX=1; use ./scripts/run_llama.sh)"
 else
-    info "llama.cpp is ready! You can start using it now while MLX builds."
+    info "llama.cpp is ready!"
 fi
 
 # ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Updates release tag to `prism-b8796-e2d6742` (rebased prism branch on latest upstream master + Q1_0 CUDA and CPU optimization PRs)
- Auto-detects and downloads correct binary for all backends: CPU, CUDA 12.4/12.8, Vulkan, ROCm, HIP
- Adds Windows CPU fallback when no GPU detected (addresses #32)
- Adds Intel Mac support — CPU-only build, skips MLX (addresses #4)
- Expands README with build-from-source instructions for all backends
- Adds `build_cpu_linux.sh` script

## Addresses
- Closes #32 (Windows CPU fallback — we ship pre-built CPU binaries now)
- Closes #4 (Intel Mac x86 — pre-built binary + source build support)

## Test plan
- [ ] macOS Apple Silicon: `./setup.sh` downloads arm64 Metal binary
- [ ] macOS Intel: `./setup.sh` downloads x64 CPU binary, skips MLX
- [ ] Linux CUDA: `./scripts/download_binaries.sh` detects CUDA version
- [ ] Linux no GPU: downloads CPU binary to `bin/cpu/`
- [ ] Windows no GPU: `setup.ps1` downloads CPU binary
- [ ] Windows CUDA: `setup.ps1` downloads CUDA 12.4 binary