### PR TITLE
fix: escape chat-template JSON on Windows PowerShell 5.1

### DIFF
--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -63,7 +63,7 @@ Write-Host "  API:  http://localhost:$Port/v1/chat/completions"
 Write-Host "  Press Ctrl+C to stop."
 Write-Host ""
 
-$ChatTemplateKwargs = if ($IsWindows) { '{\"enable_thinking\": false}' } else { '{"enable_thinking": false}' }
+$ChatTemplateKwargs = if ($PSVersionTable.PSEdition -eq 'Desktop') { '{\"enable_thinking\": false}' } else { '{"enable_thinking": false}' }
 
 $ServerArgs = @(
     "-m", $Model.FullName,


### PR DESCRIPTION
`$PSVersionTable.PSEdition` is "Desktop" on PS 5.1 (needs escaped quotes because of the stupid old legacy argument passing) and "Core" on PS 7+ (which uses Standard argument passing and preserves quotes literally). This should work correctly on both!