### PR TITLE
Make Ternary-Bonsai GGUF a required download + add Q2_0 to build tests

### DIFF
--- a/.github/workflows/build-from-source-smoke.yml
+++ b/.github/workflows/build-from-source-smoke.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   download-model:
-    name: Download model
+    name: Download models (Bonsai Q1_0 + Ternary-Bonsai Q2_0)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'build-test')
@@ -30,14 +30,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: models
-          key: models-bonsai-${{ env.BONSAI_MODEL }}-${{ hashFiles('scripts/download_models.sh') }}
-      - name: Download models
+          key: models-all-${{ env.BONSAI_MODEL }}-${{ hashFiles('scripts/download_models.sh') }}
+      - name: Download models (both families)
         if: steps.cache-models.outputs.cache-hit != 'true'
+        env:
+          BONSAI_FAMILY: all
         run: ./scripts/download_models.sh
       - name: Upload models
         uses: actions/upload-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
           retention-days: 1
           compression-level: 0
@@ -56,11 +58,15 @@ jobs:
       - name: Download models
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Build from source
         run: ./scripts/build_cpu_linux.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   linux-arm-cpu:
@@ -73,11 +79,15 @@ jobs:
       - name: Download models
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Build from source
         run: ./scripts/build_cpu_linux.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   macos-metal:
@@ -90,13 +100,21 @@ jobs:
       - name: Download models
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Build from source
         run: ./scripts/build_mac.sh
-      - name: llama-cli smoke test (CPU)
+      - name: llama-cli smoke test (Bonsai Q1_0, CPU)
         run: './scripts/run_llama.sh -ngl 0 -c 256 -st -n 50 -p "The meaning of life is"'
-      - name: llama-cli smoke test (Metal)
+      - name: llama-cli smoke test (Bonsai Q1_0, Metal)
+        run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0, CPU)
+        env:
+          BONSAI_FAMILY: ternary
+        run: './scripts/run_llama.sh -ngl 0 -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0, Metal)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 50 -p "The meaning of life is"'
 
   macos-intel:
@@ -109,10 +127,14 @@ jobs:
       - name: Download models
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Build from source
         run: ./scripts/build_mac.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 

--- a/.github/workflows/manual-platform-smoke.yml
+++ b/.github/workflows/manual-platform-smoke.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   download-model:
-    name: Download model
+    name: Download models (Bonsai Q1_0 + Ternary-Bonsai Q2_0)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'smoke-test')
@@ -66,14 +66,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: models
-          key: models-bonsai-${{ env.BONSAI_MODEL }}-${{ hashFiles('scripts/download_models.sh') }}
-      - name: Download models
+          key: models-all-${{ env.BONSAI_MODEL }}-${{ hashFiles('scripts/download_models.sh') }}
+      - name: Download models (both families)
         if: steps.cache-models.outputs.cache-hit != 'true'
+        env:
+          BONSAI_FAMILY: all
         run: ./scripts/download_models.sh
       - name: Upload models
         uses: actions/upload-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
           retention-days: 1
           compression-level: 0
@@ -93,7 +95,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -112,7 +114,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   windows-x86-cpu:
@@ -126,7 +132,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         shell: pwsh
@@ -147,8 +153,13 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
           .\setup.ps1
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
         shell: pwsh
+        run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        shell: pwsh
+        env:
+          BONSAI_FAMILY: ternary
         run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
 
   macos-metal:
@@ -162,7 +173,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -178,16 +189,29 @@ jobs:
             bin
             mlx
             models/Bonsai-${{ env.BONSAI_MODEL }}-mlx
+            models/Ternary-Bonsai-${{ env.BONSAI_MODEL }}-mlx
           key: ${{ runner.os }}-${{ runner.arch }}-bonsai-bin-mlx-${{ hashFiles('scripts/download_binaries.sh', 'setup.sh') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-bonsai-bin-mlx-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test (CPU)
+      - name: llama-cli smoke test (Bonsai Q1_0, CPU)
         run: './scripts/run_llama.sh -ngl 0 -c 256 -st -n 50 -p "The meaning of life is"'
-      - name: llama-cli smoke test (Metal)
+      - name: llama-cli smoke test (Bonsai Q1_0, Metal)
         run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 50 -p "The meaning of life is"'
-      - name: MLX smoke test
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0, CPU)
+        env:
+          BONSAI_FAMILY: ternary
+        run: './scripts/run_llama.sh -ngl 0 -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0, Metal)
+        env:
+          BONSAI_FAMILY: ternary
+        run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: MLX smoke test (Bonsai 1-bit)
+        run: './scripts/run_mlx.sh -n 50 -p "The meaning of life is"'
+      - name: MLX smoke test (Ternary-Bonsai 2-bit)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_mlx.sh -n 50 -p "The meaning of life is"'
 
   macos-intel-cpu:
@@ -201,7 +225,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -219,7 +243,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   linux-arm-cpu:
@@ -233,7 +261,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -249,7 +277,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   linux-x86-vulkan:
@@ -263,7 +295,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Install Vulkan (lavapipe CPU driver)
         run: |
@@ -285,8 +317,14 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-vulkan-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli Vulkan smoke test
+      - name: llama-cli Vulkan smoke test (Bonsai Q1_0)
         env:
+          VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
+          VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
+        run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 10 -p "The meaning of life is"'
+      - name: llama-cli Vulkan smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
           VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
           VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
         run: './scripts/run_llama.sh -ngl 99 -c 256 -st -n 10 -p "The meaning of life is"'
@@ -302,7 +340,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         shell: pwsh
@@ -322,8 +360,13 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
           .\setup.ps1
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
         shell: pwsh
+        run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        shell: pwsh
+        env:
+          BONSAI_FAMILY: ternary
         run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
 
   # ──────────────────────────────────────────
@@ -343,7 +386,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -362,7 +405,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-cuda-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   windows-cuda:
@@ -378,7 +425,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         shell: pwsh
@@ -399,8 +446,13 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
           .\setup.ps1
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
         shell: pwsh
+        run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        shell: pwsh
+        env:
+          BONSAI_FAMILY: ternary
         run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
 
   linux-amd:
@@ -416,7 +468,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -435,7 +487,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-amd-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   windows-amd:
@@ -451,7 +507,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         shell: pwsh
@@ -472,8 +528,13 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
           .\setup.ps1
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
         shell: pwsh
+        run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        shell: pwsh
+        env:
+          BONSAI_FAMILY: ternary
         run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
 
   linux-vulkan:
@@ -489,7 +550,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         run: |
@@ -508,7 +569,11 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-vulkan-bonsai-bin-
       - name: Setup
         run: ./setup.sh
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
+        run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        env:
+          BONSAI_FAMILY: ternary
         run: './scripts/run_llama.sh -c 256 -st -n 50 -p "The meaning of life is"'
 
   windows-vulkan:
@@ -524,7 +589,7 @@ jobs:
         if: ${{ !inputs.force_fresh_download }}
         uses: actions/download-artifact@v4
         with:
-          name: bonsai-models
+          name: all-models
           path: models
       - name: Log runner hardware
         shell: pwsh
@@ -545,6 +610,11 @@ jobs:
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
           .\setup.ps1
-      - name: llama-cli smoke test
+      - name: llama-cli smoke test (Bonsai Q1_0)
         shell: pwsh
+        run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"
+      - name: llama-cli smoke test (Ternary-Bonsai Q2_0)
+        shell: pwsh
+        env:
+          BONSAI_FAMILY: ternary
         run: .\scripts\run_llama.ps1 -c 256 -st -n 50 -p "The meaning of life is"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Set `BONSAI_FAMILY=ternary` to download and run this family (default family is `
 
 ### Environment variables
 
-Both variables are optional. **If you set neither, the default is `Bonsai-8B` (1-bit, 8 billion parameters)** — that's what plain `./setup.sh` downloads and runs. They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every Mac/Linux `run_*` / `start_*` script. The Windows PowerShell run/start scripts currently only honor `BONSAI_MODEL` — Windows runtime `BONSAI_FAMILY` support is on the roadmap.
+Both variables are optional. **If you set neither, the default is `Bonsai-8B` (1-bit, 8 billion parameters)** — that's what plain `./setup.sh` downloads and runs. They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every `run_*` / `start_*` script (Linux, macOS, and Windows).
 
 | Variable        | Default  | Valid values                   | Purpose |
 |-----------------|----------|--------------------------------|---------|

--- a/README.md
+++ b/README.md
@@ -95,22 +95,22 @@ Set `BONSAI_MODEL` to choose which size to download and run (default: `8B`).
 
 ### Ternary-Bonsai (1.58-bit)
 
-MLX 2-bit supported out of the box. GGUFs (`Q2_0`, etc.) coming soon. See the [Ternary-Bonsai HF collection](https://huggingface.co/collections/prism-ml/ternary-bonsai) and the [whitepaper](ternary-bonsai-8b-whitepaper.pdf).
+Available in GGUF (`Q2_0`) and MLX (2-bit) formats. See the [Ternary-Bonsai HF collection](https://huggingface.co/collections/prism-ml/ternary-bonsai) and the [whitepaper](ternary-bonsai-8b-whitepaper.pdf).
 
-| Model                  | Format        | HuggingFace Repo                                                                                                |
-|------------------------|---------------|-----------------------------------------------------------------------------------------------------------------|
-| Ternary-Bonsai-8B      | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)               |
-| Ternary-Bonsai-4B      | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)               |
-| Ternary-Bonsai-1.7B    | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)           |
-| Ternary-Bonsai-8B      | GGUF          | [prism-ml/Ternary-Bonsai-8B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf) — *coming soon*       |
-| Ternary-Bonsai-4B      | GGUF          | [prism-ml/Ternary-Bonsai-4B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-gguf) — *coming soon*       |
-| Ternary-Bonsai-1.7B    | GGUF          | [prism-ml/Ternary-Bonsai-1.7B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-gguf) — *coming soon*   |
+| Model                  | Format        | HuggingFace Repo                                                                                        |
+|------------------------|---------------|---------------------------------------------------------------------------------------------------------|
+| Ternary-Bonsai-8B      | GGUF          | [prism-ml/Ternary-Bonsai-8B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf)               |
+| Ternary-Bonsai-8B      | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)       |
+| Ternary-Bonsai-4B      | GGUF          | [prism-ml/Ternary-Bonsai-4B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-gguf)               |
+| Ternary-Bonsai-4B      | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)       |
+| Ternary-Bonsai-1.7B    | GGUF          | [prism-ml/Ternary-Bonsai-1.7B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-gguf)           |
+| Ternary-Bonsai-1.7B    | MLX (2-bit)   | [prism-ml/Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)   |
 
-When you set `BONSAI_FAMILY=ternary`, `setup.sh` downloads the MLX 2-bit weights today; GGUFs will be fetched automatically once the HF repos go public.
+Set `BONSAI_FAMILY=ternary` to download and run this family (default family is `bonsai`).
 
 ### Environment variables
 
-Both variables are optional. **If you set neither, the default is `Bonsai-8B` (1-bit, 8 billion parameters)** — that's what plain `./setup.sh` downloads and runs. They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every Mac/Linux `run_*` / `start_*` script. The Windows PowerShell run/start scripts currently only honor `BONSAI_MODEL`; `BONSAI_FAMILY` support on Windows run-time will land alongside the public Ternary-Bonsai GGUFs.
+Both variables are optional. **If you set neither, the default is `Bonsai-8B` (1-bit, 8 billion parameters)** — that's what plain `./setup.sh` downloads and runs. They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every Mac/Linux `run_*` / `start_*` script. The Windows PowerShell run/start scripts currently only honor `BONSAI_MODEL` — Windows runtime `BONSAI_FAMILY` support is on the roadmap.
 
 | Variable        | Default  | Valid values                   | Purpose |
 |-----------------|----------|--------------------------------|---------|

--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -19,7 +19,7 @@ Combined view across both model families. See the per-family subfolders below fo
 ## Model Families
 
 - **[Bonsai (1-bit)](bonsai/)** — the original 1-bit Bonsai family (8B, 4B, 1.7B) in GGUF and MLX 1-bit formats.
-- **[Ternary-Bonsai (1.58-bit)](ternary-bonsai/)** — the ternary Bonsai family (8B, 4B, 1.7B) in MLX 2-bit (GGUF coming soon).
+- **[Ternary-Bonsai (1.58-bit)](ternary-bonsai/)** — the ternary Bonsai family (8B, 4B, 1.7B) in GGUF (`Q2_0`) and MLX (2-bit) formats.
 
 Each subfolder has its own README with results, submission templates, and filename conventions.
 

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -12,21 +12,21 @@ Coming soon...
 
 ## Available Formats
 
-- **MLX 2-bit** — supported out of the box:
-  - [prism-ml/Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
-  - [prism-ml/Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
-  - [prism-ml/Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)
-- **GGUF** (`Q2_0`, etc.) — coming soon:
+- **GGUF** (`Q2_0`):
   - [prism-ml/Ternary-Bonsai-8B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf)
   - [prism-ml/Ternary-Bonsai-4B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-gguf)
   - [prism-ml/Ternary-Bonsai-1.7B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-gguf)
+- **MLX (2-bit)**:
+  - [prism-ml/Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
+  - [prism-ml/Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
+  - [prism-ml/Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)
 
 ## How to Submit
 
-1. Run `./setup.sh` to download models and binaries
+1. Run `BONSAI_FAMILY=ternary ./setup.sh` to download models and binaries
 2. Pick a template and copy it to a new file:
+   - **llama.cpp** (CPU, Metal, CUDA, Vulkan, ROCm): [TERNARY-TEMPLATE-llama-cpp.md](TERNARY-TEMPLATE-llama-cpp.md)
    - **MLX (2-bit)** (Apple Silicon only): [TERNARY-TEMPLATE-mlx.md](TERNARY-TEMPLATE-mlx.md)
-   - **llama.cpp** (CPU, Metal, CUDA, Vulkan, ROCm): [TERNARY-TEMPLATE-llama-cpp.md](TERNARY-TEMPLATE-llama-cpp.md) — *accepting once GGUFs ship*
 
    Use this naming convention:
 

--- a/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
@@ -18,8 +18,6 @@
   - Save as community-benchmarks/ternary-bonsai/<backend>-<hardware>-<os>.md (lowercase, dashes)
 -->
 
-> **Note:** Ternary-Bonsai GGUFs (`Q2_0`, etc.) are coming soon. Once released, submissions for llama.cpp backends will be accepted here.
-
 ## Summary
 
 <!-- Quick overview: hardware, backend, headline numbers, anything interesting.
@@ -37,11 +35,11 @@ find bin/ llama.cpp/ -name "llama-bench" -type f 2>/dev/null
 ```bash
 # GPU (Metal / CUDA / Vulkan / ROCm) — adjust BENCH path:
 BENCH=bin/mac/llama-bench
-$BENCH -m models/gguf/ternary-8B/*.gguf -ngl 99 -fa 1
+$BENCH -m models/ternary-gguf/8B/*.gguf -ngl 99 -fa 1
 
 # CPU only:
-# $BENCH -m models/gguf/ternary-8B/*.gguf -ngl 0 -fa 1 -t $(sysctl -n hw.logicalcpu)  # macOS
-# $BENCH -m models/gguf/ternary-8B/*.gguf -ngl 0 -fa 1 -t $(nproc)                     # Linux
+# $BENCH -m models/ternary-gguf/8B/*.gguf -ngl 0 -fa 1 -t $(sysctl -n hw.logicalcpu)  # macOS
+# $BENCH -m models/ternary-gguf/8B/*.gguf -ngl 0 -fa 1 -t $(nproc)                     # Linux
 ```
 
 (paste llama-bench output here — raw markdown table, no code block)
@@ -49,7 +47,7 @@ $BENCH -m models/gguf/ternary-8B/*.gguf -ngl 99 -fa 1
 ### Ternary-Bonsai-4B
 
 ```bash
-$BENCH -m models/gguf/ternary-4B/*.gguf -ngl 99 -fa 1
+$BENCH -m models/ternary-gguf/4B/*.gguf -ngl 99 -fa 1
 ```
 
 (paste llama-bench output here, or remove if skipped)
@@ -57,7 +55,7 @@ $BENCH -m models/gguf/ternary-4B/*.gguf -ngl 99 -fa 1
 ### Ternary-Bonsai-1.7B
 
 ```bash
-$BENCH -m models/gguf/ternary-1.7B/*.gguf -ngl 99 -fa 1
+$BENCH -m models/ternary-gguf/1.7B/*.gguf -ngl 99 -fa 1
 ```
 
 (paste llama-bench output here, or remove if skipped)

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -77,17 +77,23 @@ download_one() {
     esac
 
     # GGUF — stderr flows to the user so auth/network errors are visible.
-    if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/*.gguf >/dev/null 2>&1; then
-        info "GGUF ${_display} already present in ${_gguf_dir}/"
+    # Fast-path and post-download checks both filter on the target quant pattern
+    # (not just any *.gguf) so a leftover F16 or other quant from an earlier
+    # download doesn't get picked up at runtime.
+    if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
+        info "GGUF ${_display} (${_gguf_pattern}) already present in ${_gguf_dir}/"
     else
         step "Downloading GGUF ${_display} (${_gguf_pattern}) from ${_gguf_repo} ..."
         mkdir -p "$_gguf_dir"
-        if hf_download "$_gguf_repo" "$_gguf_dir" "$_gguf_pattern"; then
-            info "GGUF ${_display} downloaded to ${_gguf_dir}/"
-        else
+        if ! hf_download "$_gguf_repo" "$_gguf_dir" "$_gguf_pattern"; then
             err "Failed to download GGUF ${_display} from ${_gguf_repo}."
             exit 1
         fi
+        if ! ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
+            err "Download reported success but no file matching ${_gguf_pattern} was written to ${_gguf_dir}/."
+            exit 1
+        fi
+        info "GGUF ${_display} downloaded to ${_gguf_dir}/"
     fi
 
     # MLX (macOS Apple Silicon only; skipped on Intel or when BONSAI_SKIP_MLX=1)

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -35,15 +35,19 @@ if [ -z "$PY" ] || ! "$PY" -c "import huggingface_hub" 2>/dev/null; then
 fi
 
 # ── Helper: download a HF repo via Python ──
+# Third arg (optional) is a comma-separated allow_patterns filter — when set,
+# only files matching any of those glob patterns are downloaded.
 hf_download() {
     _repo="$1"
     _dest="$2"
+    _patterns="${3:-}"
     "$PY" -c "
 from huggingface_hub import snapshot_download
-snapshot_download(
-    repo_id='$_repo',
-    local_dir='$_dest',
-)
+kwargs = {'repo_id': '$_repo', 'local_dir': '$_dest'}
+_p = '$_patterns'
+if _p:
+    kwargs['allow_patterns'] = [p for p in _p.split(',') if p]
+snapshot_download(**kwargs)
 "
 }
 
@@ -51,6 +55,8 @@ snapshot_download(
 download_one() {
     _family="$1"
     _size="$2"
+    # Each GGUF repo ships multiple quants (e.g. F16 + Q2_0); we only want the
+    # quant the demo is built around, so restrict the download via allow_patterns.
     case "$_family" in
         bonsai)
             _gguf_repo="prism-ml/Bonsai-${_size}-gguf"
@@ -58,6 +64,7 @@ download_one() {
             _gguf_dir="models/gguf/${_size}"
             _mlx_dir="models/Bonsai-${_size}-mlx"
             _display="Bonsai-${_size}"
+            _gguf_pattern="*Q1_0*.gguf"
             ;;
         ternary)
             _gguf_repo="prism-ml/Ternary-Bonsai-${_size}-gguf"
@@ -65,6 +72,7 @@ download_one() {
             _gguf_dir="models/ternary-gguf/${_size}"
             _mlx_dir="models/Ternary-Bonsai-${_size}-mlx"
             _display="Ternary-Bonsai-${_size}"
+            _gguf_pattern="*Q2_0*.gguf"
             ;;
     esac
 
@@ -72,9 +80,9 @@ download_one() {
     if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/*.gguf >/dev/null 2>&1; then
         info "GGUF ${_display} already present in ${_gguf_dir}/"
     else
-        step "Downloading GGUF ${_display} from ${_gguf_repo} ..."
+        step "Downloading GGUF ${_display} (${_gguf_pattern}) from ${_gguf_repo} ..."
         mkdir -p "$_gguf_dir"
-        if hf_download "$_gguf_repo" "$_gguf_dir"; then
+        if hf_download "$_gguf_repo" "$_gguf_dir" "$_gguf_pattern"; then
             info "GGUF ${_display} downloaded to ${_gguf_dir}/"
         else
             err "Failed to download GGUF ${_display} from ${_gguf_repo}."

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -58,7 +58,6 @@ download_one() {
             _gguf_dir="models/gguf/${_size}"
             _mlx_dir="models/Bonsai-${_size}-mlx"
             _display="Bonsai-${_size}"
-            _gguf_optional=0
             ;;
         ternary)
             _gguf_repo="prism-ml/Ternary-Bonsai-${_size}-gguf"
@@ -66,29 +65,12 @@ download_one() {
             _gguf_dir="models/ternary-gguf/${_size}"
             _mlx_dir="models/Ternary-Bonsai-${_size}-mlx"
             _display="Ternary-Bonsai-${_size}"
-            _gguf_optional=1   # GGUFs not yet public — skip gracefully on failure
             ;;
     esac
 
-    # GGUF
-    #   Required (bonsai): let stderr flow to the user so they see auth/network
-    #   errors directly. Optional (ternary, not-yet-public): capture stderr to
-    #   a log file so the friendly "coming soon" message stays clean but users
-    #   can still inspect the full error.
+    # GGUF — stderr flows to the user so auth/network errors are visible.
     if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/*.gguf >/dev/null 2>&1; then
         info "GGUF ${_display} already present in ${_gguf_dir}/"
-    elif [ "$_gguf_optional" = 1 ]; then
-        step "Downloading GGUF ${_display} from ${_gguf_repo} ..."
-        mkdir -p "$_gguf_dir"
-        _errlog="models/.${_display}-gguf-download.log"
-        if hf_download "$_gguf_repo" "$_gguf_dir" 2>"$_errlog"; then
-            info "GGUF ${_display} downloaded to ${_gguf_dir}/"
-            rm -f "$_errlog"
-        else
-            warn "GGUF ${_display} not available yet (coming soon — repo: ${_gguf_repo})."
-            warn "  Full error saved to: ${_errlog}"
-            rm -rf "$_gguf_dir"
-        fi
     else
         step "Downloading GGUF ${_display} from ${_gguf_repo} ..."
         mkdir -p "$_gguf_dir"

--- a/scripts/run_llama.ps1
+++ b/scripts/run_llama.ps1
@@ -1,18 +1,29 @@
 $ErrorActionPreference = "Stop"
 
-$BonsaiModel = if ($env:BONSAI_MODEL) { $env:BONSAI_MODEL } else { "8B" }
+$BonsaiModel  = if ($env:BONSAI_MODEL)  { $env:BONSAI_MODEL }  else { "8B" }
+$BonsaiFamily = if ($env:BONSAI_FAMILY) { $env:BONSAI_FAMILY } else { "bonsai" }
 if ($BonsaiModel -notin @("8B", "4B", "1.7B")) {
     Write-Host "[ERR] Unknown BONSAI_MODEL='$BonsaiModel'. Valid values: 8B, 4B, 1.7B" -ForegroundColor Red
+    exit 1
+}
+if ($BonsaiFamily -notin @("bonsai", "ternary")) {
+    Write-Host "[ERR] Unknown BONSAI_FAMILY='$BonsaiFamily'. Valid values: bonsai, ternary" -ForegroundColor Red
     exit 1
 }
 
 $DemoDir = Split-Path $PSScriptRoot -Parent
 Set-Location $DemoDir
 
-$ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
+if ($BonsaiFamily -eq "ternary") {
+    $ModelDir = Join-Path $DemoDir "models\ternary-gguf\$BonsaiModel"
+    $Display = "Ternary-Bonsai-$BonsaiModel"
+} else {
+    $ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
+    $Display = "Bonsai-$BonsaiModel"
+}
 $Model = Get-ChildItem -Path $ModelDir -Filter *.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $Model) {
-    Write-Host "[ERR] GGUF model not found for Bonsai-$BonsaiModel in $ModelDir" -ForegroundColor Red
+    Write-Host "[ERR] GGUF model not found for $Display in $ModelDir" -ForegroundColor Red
     Write-Host "      Run .\setup.ps1 first." -ForegroundColor Yellow
     exit 1
 }

--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -1,8 +1,13 @@
 $ErrorActionPreference = "Stop"
 
-$BonsaiModel = if ($env:BONSAI_MODEL) { $env:BONSAI_MODEL } else { "8B" }
+$BonsaiModel  = if ($env:BONSAI_MODEL)  { $env:BONSAI_MODEL }  else { "8B" }
+$BonsaiFamily = if ($env:BONSAI_FAMILY) { $env:BONSAI_FAMILY } else { "bonsai" }
 if ($BonsaiModel -notin @("8B", "4B", "1.7B")) {
     Write-Host "[ERR] Unknown BONSAI_MODEL='$BonsaiModel'. Valid values: 8B, 4B, 1.7B" -ForegroundColor Red
+    exit 1
+}
+if ($BonsaiFamily -notin @("bonsai", "ternary")) {
+    Write-Host "[ERR] Unknown BONSAI_FAMILY='$BonsaiFamily'. Valid values: bonsai, ternary" -ForegroundColor Red
     exit 1
 }
 
@@ -18,10 +23,16 @@ try {
     exit 1
 } catch {}
 
-$ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
+if ($BonsaiFamily -eq "ternary") {
+    $ModelDir = Join-Path $DemoDir "models\ternary-gguf\$BonsaiModel"
+    $Display = "Ternary-Bonsai-$BonsaiModel"
+} else {
+    $ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
+    $Display = "Bonsai-$BonsaiModel"
+}
 $Model = Get-ChildItem -Path $ModelDir -Filter *.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $Model) {
-    Write-Host "[ERR] GGUF model not found for Bonsai-$BonsaiModel in $ModelDir" -ForegroundColor Red
+    Write-Host "[ERR] GGUF model not found for $Display in $ModelDir" -ForegroundColor Red
     Write-Host "      Run .\setup.ps1 first." -ForegroundColor Yellow
     exit 1
 }

--- a/setup.ps1
+++ b/setup.ps1
@@ -213,12 +213,10 @@ function Download-GgufModel($Family, $Size) {
         $repo = "prism-ml/Ternary-Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\ternary-gguf\$Size"
         $display = "Ternary-Bonsai-$Size"
-        $optional = $true   # Ternary GGUFs not yet public - skip gracefully on failure
     } else {
         $repo = "prism-ml/Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\gguf\$Size"
         $display = "Bonsai-$Size"
-        $optional = $false
     }
 
     if (Test-Path "$dir\*.gguf") {
@@ -234,31 +232,12 @@ function Download-GgufModel($Family, $Size) {
         exit 1
     }
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
-
-    # Required: let stderr flow to the user so they see auth/network/etc errors.
-    # Optional: capture stderr to a log file so the friendly "coming soon"
-    # message stays clean but users can still inspect the full error.
-    $errLog = $null
-    if ($optional) {
-        $errLog = Join-Path $PSScriptRoot "models\.$display-gguf-download.log"
-        & $HfCli download $repo --local-dir $dir 2>$errLog
-    } else {
-        & $HfCli download $repo --local-dir $dir
-    }
+    & $HfCli download $repo --local-dir $dir
     $DownloadExitCode = $LASTEXITCODE
     $DownloadedGguf = Get-ChildItem -Path $dir -Filter "*.gguf" -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($DownloadExitCode -ne 0 -or -not $DownloadedGguf) {
-        if ($optional) {
-            Write-Host "[WARN] GGUF $display not available yet (coming soon - repo: $repo)." -ForegroundColor Yellow
-            Write-Host "  Full error saved to: $errLog" -ForegroundColor Yellow
-            Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue
-            return
-        }
         Write-Host "[ERR] Failed to download GGUF $display. Try running '$HfCli download $repo --local-dir $dir' manually." -ForegroundColor Red
         exit 1
-    }
-    if ($optional -and $errLog -and (Test-Path $errLog)) {
-        Remove-Item $errLog -Force -ErrorAction SilentlyContinue
     }
     Write-Host "[OK] GGUF $display downloaded." -ForegroundColor Green
 }

--- a/setup.ps1
+++ b/setup.ps1
@@ -209,14 +209,19 @@ if ($GpuType -eq "cuda") {
 Write-Host "==> Downloading model (family=$BonsaiFamily size=$BonsaiModel) ..." -ForegroundColor Cyan
 
 function Download-GgufModel($Family, $Size) {
+    # Each GGUF repo ships multiple quants (e.g. F16 + Q2_0); only fetch the
+    # quant the demo is built around so the directory deterministically holds
+    # one .gguf and we skip multi-GB reference weights we don't need.
     if ($Family -eq "ternary") {
         $repo = "prism-ml/Ternary-Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\ternary-gguf\$Size"
         $display = "Ternary-Bonsai-$Size"
+        $pattern = "*Q2_0*.gguf"
     } else {
         $repo = "prism-ml/Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\gguf\$Size"
         $display = "Bonsai-$Size"
+        $pattern = "*Q1_0*.gguf"
     }
 
     if (Test-Path "$dir\*.gguf") {
@@ -232,11 +237,11 @@ function Download-GgufModel($Family, $Size) {
         exit 1
     }
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    & $HfCli download $repo --local-dir $dir
+    & $HfCli download $repo --local-dir $dir --include $pattern
     $DownloadExitCode = $LASTEXITCODE
     $DownloadedGguf = Get-ChildItem -Path $dir -Filter "*.gguf" -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($DownloadExitCode -ne 0 -or -not $DownloadedGguf) {
-        Write-Host "[ERR] Failed to download GGUF $display. Try running '$HfCli download $repo --local-dir $dir' manually." -ForegroundColor Red
+        Write-Host "[ERR] Failed to download GGUF $display. Try running '$HfCli download $repo --local-dir $dir --include $pattern' manually." -ForegroundColor Red
         exit 1
     }
     Write-Host "[OK] GGUF $display downloaded." -ForegroundColor Green

--- a/setup.ps1
+++ b/setup.ps1
@@ -224,8 +224,11 @@ function Download-GgufModel($Family, $Size) {
         $pattern = "*Q1_0*.gguf"
     }
 
-    if (Test-Path "$dir\*.gguf") {
-        Write-Host "[OK] GGUF $display already present." -ForegroundColor Green
+    # Fast-path and post-download checks both filter on the target quant
+    # pattern (not just any *.gguf) so a leftover F16 or other quant from an
+    # earlier download doesn't get picked up at runtime.
+    if (Get-ChildItem -Path $dir -Filter $pattern -File -ErrorAction SilentlyContinue | Select-Object -First 1) {
+        Write-Host "[OK] GGUF $display ($pattern) already present." -ForegroundColor Green
         return
     }
     $HfCli = Join-Path $VenvDir "Scripts\hf.exe"
@@ -239,9 +242,9 @@ function Download-GgufModel($Family, $Size) {
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
     & $HfCli download $repo --local-dir $dir --include $pattern
     $DownloadExitCode = $LASTEXITCODE
-    $DownloadedGguf = Get-ChildItem -Path $dir -Filter "*.gguf" -ErrorAction SilentlyContinue | Select-Object -First 1
+    $DownloadedGguf = Get-ChildItem -Path $dir -Filter $pattern -File -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($DownloadExitCode -ne 0 -or -not $DownloadedGguf) {
-        Write-Host "[ERR] Failed to download GGUF $display. Try running '$HfCli download $repo --local-dir $dir --include $pattern' manually." -ForegroundColor Red
+        Write-Host "[ERR] Failed to download GGUF $display matching $pattern. Try running '$HfCli download $repo --local-dir $dir --include $pattern' manually." -ForegroundColor Red
         exit 1
     }
     Write-Host "[OK] GGUF $display downloaded." -ForegroundColor Green


### PR DESCRIPTION
Ternary-Bonsai GGUFs are public now, so drop the graceful warn-and-skip fallback and wire them into the build-test smoke workflow.

- scripts/download_models.sh, setup.ps1: ternary GGUF failures are now hard errors like bonsai (no more optional path)
- build-from-source-smoke.yml: download both families via BONSAI_FAMILY=all and run llama-cli smoke tests for both Q1_0 and Q2_0 on every hosted platform (1.7B)
- README, community-benchmarks: drop 'coming soon' annotations on ternary GGUF
- TERNARY-TEMPLATE-llama-cpp.md: fix model paths (models/ternary-gguf/<size>/)