### PR TITLE
Modification to run_llama.ps1

### DIFF
--- a/scripts/run_llama.ps1
+++ b/scripts/run_llama.ps1
@@ -32,8 +32,6 @@ if (-not $Model) {
     exit 1
 }
 
-$Display = "$FamilyDisplay-$BonsaiModel"
-
 $BinCandidates = @(
     "bin\cuda\llama-cli.exe",
     "bin\hip\llama-cli.exe",

--- a/scripts/run_llama.ps1
+++ b/scripts/run_llama.ps1
@@ -28,19 +28,11 @@ if ($BonsaiFamily -eq "ternary") {
 $Model = Get-ChildItem -Path $ModelDir -Filter *.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
 if (-not $Model) {
     Write-Host "[ERR] GGUF model not found for $FamilyDisplay-$BonsaiModel in $ModelDir" -ForegroundColor Red
-
-    $Display = "Ternary-Bonsai-$BonsaiModel"
-} else {
-    $ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
-    $Display = "Bonsai-$BonsaiModel"
-}
-$Model = Get-ChildItem -Path $ModelDir -Filter *.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
-if (-not $Model) {
-    Write-Host "[ERR] GGUF model not found for $Display in $ModelDir" -ForegroundColor Red
-
     Write-Host "      Run .\setup.ps1 first." -ForegroundColor Yellow
     exit 1
 }
+
+$Display = "$FamilyDisplay-$BonsaiModel"
 
 $BinCandidates = @(
     "bin\cuda\llama-cli.exe",


### PR DESCRIPTION
When BONSAI_FAMILY=ternary, run_llama.ps1 successfully finds the model under models/ternary-gguf/<BONSAI_MODEL>, but then the script does this
```
else {
    $ModelDir = Join-Path $DemoDir "models\gguf\$BonsaiModel"
    $Display = "Bonsai-$BonsaiModel"
}
```
which overwrites $ModelDir with "models/gguf/<BONSAI_MODEL>" and performs an unnecessary search for the binary version.

This causes ternary models to fail to load even when the GGUF exists, like this:

```
PS C:\path\to\Bonsai-demo> $env:BONSAI_FAMILY="ternary"; $env:BONSAI_MODEL="8B"
PS C:\path\to\Bonsai-demo> .\scripts\run_llama.ps1 -p "<user prompt>"
[ERR] GGUF model not found for Bonsai-8B in C:\path\to\Bonsai-demo\models\gguf\8B
      Run .\setup.ps1 first.
```

Changes:
- Remove unnecessary second model lookup
- Preserve selected model path
- Exit immediately when model cannot be found

Tested:
- Ternary-Bonsai-8B-Q2_0.gguf
- Bonsai-8B-Q1_0.gguf
- Running on CUDA llama-cli build on Windows (NVIDIA GeForce GTX 1650)