### PR TITLE
community-benchmarks: Bonsai-27B on NVIDIA DGX Spark (GB10)

### DIFF
--- a/community-benchmarks/bonsai/README.md
+++ b/community-benchmarks/bonsai/README.md
@@ -13,6 +13,12 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](cuda-rtx3080-linux.md) |
 | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](cuda-rtxa2000-debian.md) |
 
+**Bonsai-27B** results (PP512 / TG128 for the 27B model):
+
+| Hardware | Backend | 27B PP512 (t/s) | 27B TG128 (t/s) | Details |
+|----------|---------|----------------:|----------------:|---------|
+| NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44 | [link](cuda-gb10-27b-linux.md) |
+
 > Benchmarks for the **Ternary-Bonsai (1.58-bit)** family live in [../ternary-bonsai/](../ternary-bonsai/).
 
 ## How to Submit

--- a/community-benchmarks/bonsai/cuda-gb10-27b-linux.md
+++ b/community-benchmarks/bonsai/cuda-gb10-27b-linux.md
@@ -1,0 +1,50 @@
+# NVIDIA DGX Spark (GB10) — CUDA — Bonsai-27B
+
+## Summary
+
+NVIDIA DGX Spark with GB10 GPU (128 GB unified LPDDR5X memory), CUDA 13.0 on DGX OS (Ubuntu 24.04 base, aarch64). Extends the existing [GB10 results](cuda-gb10-linux.md) (8B/4B/1.7B) with the **27B model**: **~44 t/s tg128, ~1,003 t/s pp512** — full 27B-class reasoning at reading speed on a compact unified-memory box.
+
+Also tested speculative decoding against the 27B Q1_0 target on this hardware: it does not help (details in Configuration).
+
+## llama-bench Results
+
+### Bonsai-27B
+
+```bash
+BENCH=llama.cpp-prism/build/bin/llama-bench
+$BENCH -m models/gguf/27B/Bonsai-27B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           pp512 |       1003.34 ± 7.71 |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           tg128 |         44.14 ± 0.06 |
+
+build: 62061f9 (branch `prism`, built from source)
+
+## Configuration
+
+- Server-mode sustained generation (320-token responses via `/v1/chat/completions`, temp 0, 3 passes) matches llama-bench closely: 43.7 t/s.
+- Speculative decoding on the 27B Q1_0 target was consistently neutral-to-negative on this hardware — the Q1_0 forward pass is cheap enough that drafting overhead cancels verification-batching gains:
+  - `draft-dspark` with the official 27B DSpark drafter (Q4_1, `--spec-draft-n-max 4`): 21.6 t/s at 78% acceptance (vs 43.7 base)
+  - Same drafter requantized to Q2_K: 21.2 t/s (still ~2x slower than base)
+  - Bonsai-8B-Q1_0 as a `draft-simple` drafter: 43.9 t/s — exact wash with base
+  - `ngram-simple`: ~6% acceptance on reasoning-heavy output, no gain
+  - KV-cache quantization (q8_0/q4_0) and batch tuning (`-b 4096 -ub 1024`): no measurable change
+- The experimental `megakernel/rmsnorm-qmv-fuse` branch (5d906dc) measured 42.82 ± 0.08 tg128 — parity with `prism` on this GPU.
+
+## Notes
+
+- NVIDIA driver 580.126.09, CUDA 13.0, GPU compute capability 12.1
+- Numbers are stable across runs (± 0.1 t/s server-mode)
+- For contrast, standard PTQ imatrix quants of the same model (Q4_K_M, 16.6 GB) decode at ~12 t/s on this hardware (bandwidth-bound), where the DSpark drafter *does* help: 15.7 t/s (+31%) at 79% acceptance
+
+## Hardware
+
+```
+Architecture:                            aarch64
+CPU(s):                                  20 (Cortex-X925 / Cortex-A725)
+Mem:                                     119Gi unified LPDDR5X
+NVIDIA-SMI 580.126.09    Driver Version: 580.126.09    CUDA Version: 13.0
+GPU: NVIDIA GB10 (compute capability 12.1)
+```


### PR DESCRIPTION
First **27B** community benchmark for the GB10 (existing GB10 file covers 8B/4B/1.7B).

## Headline
| test | t/s |
|---|---:|
| pp512 | 1,003.34 ± 7.71 |
| tg128 | 44.14 ± 0.06 |

`llama-bench` on the `prism` branch (62061f9), CUDA 13.0, driver 580.126.09. Server-mode sustained generation matches at 43.7 t/s (320-token responses, temp 0, 3 passes).

## Also included: speculative decoding findings on this hardware
Tested the official DSpark drafter (Q4_1 and a Q2_K requant), Bonsai-8B-Q1_0 via `draft-simple`, and ngram speculation against the 27B Q1_0 target — all neutral-to-negative on GB10 (details in the file). The Q1_0 forward pass appears cheap enough on this unified-memory part that drafting overhead cancels the verification-batching win. The same drafter DOES deliver +31% on a 16.6GB Q4_K_M PTQ quant of the same model on the same box, which supports that read. Happy to run additional configs if useful.

Also appended a small 27B results table to the bonsai README (kept the 8B table untouched — happy to reformat if you'd rather fold it in differently).

Amazing release — the 27B QAT work is remarkable. 🌳