### PR TITLE
community-benchmarks: 27B tables and templates

### DIFF
--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -4,7 +4,7 @@ Benchmark results submitted by the community, organized by model. **We are espec
 
 ## Bonsai-27B
 
-The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (`Q2_0`). Optional column: decode speed with the bundled DSpark drafter (`BONSAI_SPECULATIVE=1`, speculative decoding).
+The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (`Q2_0`). Optional column: decode speed with the paired DSpark drafter, where the submitter measured it (llama-server via `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh`; on MLX via community harnesses such as dspark-mlx). Plain `llama-bench` does not exercise the drafter.
 
 | Family | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
 |--------|----------|---------|------------:|------------:|----------------:|---------|

--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -1,10 +1,19 @@
 # Community Benchmarks
 
-Benchmark results submitted by the community, organized by model family.
+Benchmark results submitted by the community, organized by model. **We are especially looking for Bonsai-27B numbers right now**: any hardware, any backend, five minutes with `llama-bench`. See [How to Submit](#how-to-submit).
 
-## All Results
+## Bonsai-27B
 
-Combined view across both model families. See the per-family subfolders below for details, submission templates, and filename conventions.
+The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (`Q2_0`). Optional column: decode speed with the bundled DSpark drafter (`BONSAI_SPECULATIVE=1`, speculative decoding).
+
+| Family | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
+|--------|----------|---------|------------:|------------:|----------------:|---------|
+| Ternary | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](ternary-bonsai/cuda-rtx5060ti-linux.md) |
+| Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | no gain on this HW | [link](bonsai/cuda-gb10-27b-linux.md) |
+| Ternary | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
+| Ternary | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
+
+## 8B and smaller
 
 | Family | Hardware | Backend | 8B PP512 (t/s) | 8B TG128 (t/s) | Details |
 |--------|----------|---------|---------------:|---------------:|---------|
@@ -14,18 +23,18 @@ Combined view across both model families. See the per-family subfolders below fo
 | Bonsai (1-bit) | AMD Strix Halo 128 GB | llama.cpp ROCm HIP | 1,325 | 96 | [link](bonsai/rocm-hip-strix-halo-128gb-archlinux.md) |
 | Bonsai (1-bit) | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](bonsai/cuda-rtx3080-linux.md) |
 | Bonsai (1-bit) | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](bonsai/cuda-rtxa2000-debian.md) |
-| Ternary-Bonsai (1.58-bit) | *coming soon* | | | | |
+| Ternary | *no submissions yet* | | | | |
 
 ## Model Families
 
-- **[Bonsai (1-bit)](bonsai/)** — the original 1-bit Bonsai family (8B, 4B, 1.7B) in GGUF and MLX 1-bit formats.
-- **[Ternary-Bonsai (1.58-bit)](ternary-bonsai/)** — the ternary Bonsai family (8B, 4B, 1.7B) in GGUF (`Q2_0`) and MLX (2-bit) formats.
+- **[Bonsai (1-bit)](bonsai/)**: the 1-bit Bonsai family (27B, 8B, 4B, 1.7B) in GGUF and MLX 1-bit formats.
+- **[Ternary-Bonsai](ternary-bonsai/)**: the ternary Bonsai family (27B, 8B, 4B, 1.7B) in GGUF (`Q2_0`) and MLX (2-bit) formats.
 
 Each subfolder has its own README with results, submission templates, and filename conventions.
 
 ## How to Submit
 
-1. Run `./setup.sh` to download models and binaries
+1. Run `./setup.sh` to download models and binaries (`BONSAI_FAMILY=bonsai` for the 1-bit family; the default is ternary)
 2. Go into the subfolder for your model family and follow its `README.md`:
    - [bonsai/README.md](bonsai/README.md)
    - [ternary-bonsai/README.md](ternary-bonsai/README.md)

--- a/community-benchmarks/bonsai/README.md
+++ b/community-benchmarks/bonsai/README.md
@@ -4,6 +4,14 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 
 ## Results
 
+### Bonsai-27B
+
+| Hardware | Backend | PP512 (t/s) | TG128 (t/s) | Details |
+|----------|---------|------------:|------------:|---------|
+| NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | [link](cuda-gb10-27b-linux.md) |
+
+### 8B and smaller
+
 | Hardware | Backend | 8B PP512 (t/s) | 8B TG128 (t/s) | Details |
 |----------|---------|---------------:|---------------:|---------|
 | Apple M4 Pro 48 GB | llama.cpp Metal | 487 | 117 | [link](metal-m4-pro-48gb-macos.md) |
@@ -12,12 +20,6 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 | AMD Strix Halo 128 GB | llama.cpp ROCm HIP | 1,325 | 96 | [link](rocm-hip-strix-halo-128gb-archlinux.md) |
 | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](cuda-rtx3080-linux.md) |
 | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](cuda-rtxa2000-debian.md) |
-
-**Bonsai-27B** results (PP512 / TG128 for the 27B model):
-
-| Hardware | Backend | 27B PP512 (t/s) | 27B TG128 (t/s) | Details |
-|----------|---------|----------------:|----------------:|---------|
-| NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44 | [link](cuda-gb10-27b-linux.md) |
 
 > Benchmarks for the **Ternary-Bonsai (1.58-bit)** family live in [../ternary-bonsai/](../ternary-bonsai/).
 

--- a/community-benchmarks/bonsai/TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/bonsai/TEMPLATE-llama-cpp.md
@@ -33,6 +33,7 @@ find bin/ llama.cpp/ -name "llama-bench" -type f 2>/dev/null
 ### Bonsai-27B (the one we most want numbers for!)
 
 ```bash
+# GPU (Metal / CUDA / Vulkan / ROCm) — adjust BENCH path (bin/mac, bin/cuda, bin/rocm, bin/vulkan, bin/cpu):
 BENCH=bin/mac/llama-bench
 $BENCH -m models/gguf/27B/Bonsai-27B-Q1_0.gguf -ngl 99 -fa 1
 ```

--- a/community-benchmarks/bonsai/TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/bonsai/TEMPLATE-llama-cpp.md
@@ -30,6 +30,15 @@ Run `./setup.sh` first, then find your `llama-bench` binary:
 find bin/ llama.cpp/ -name "llama-bench" -type f 2>/dev/null
 ```
 
+### Bonsai-27B (the one we most want numbers for!)
+
+```bash
+BENCH=bin/mac/llama-bench
+$BENCH -m models/gguf/27B/Bonsai-27B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+(paste llama-bench output here, or remove this section if you skipped the 27B)
+
 ### Bonsai-8B
 
 ```bash

--- a/community-benchmarks/bonsai/TEMPLATE-mlx.md
+++ b/community-benchmarks/bonsai/TEMPLATE-mlx.md
@@ -24,9 +24,19 @@
 
 ## MLX Results
 
+### Bonsai-27B (the one we most want numbers for!)
+
+```bash
+.venv/bin/python -m mlx_lm.benchmark --model models/Bonsai-27B-mlx -p 512 -g 128
+```
+
+(paste MLX benchmark output here, or remove this section if you skipped the 27B)
+
 ### Bonsai-8B
 
-<!-- TODO: Add MLX benchmark commands once script is finalized -->
+```bash
+.venv/bin/python -m mlx_lm.benchmark --model models/Bonsai-8B-mlx -p 512 -g 128
+```
 
 (paste MLX benchmark output here — raw output, no code block)
 

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -4,19 +4,31 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 
 ## Results
 
-Coming soon...
+### Ternary-Bonsai-27B
+
+| Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
+|----------|---------|------------:|------------:|----------------:|---------|
+| NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](cuda-rtx5060ti-linux.md) |
+| Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](mlx-m5-pro-macos.md) |
+| Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](mlx-m5-pro-macos.md) |
+
+### 8B and smaller
+
+No submissions yet; be the first!
 
 | Hardware | Backend | 8B PP512 (t/s) | 8B TG128 (t/s) | Details |
-|----------|---------|----------------|----------------|---------|
+|----------|---------|---------------:|---------------:|---------|
 | | | | | |
 
 ## Available Formats
 
 - **GGUF** (`Q2_0`):
+  - [prism-ml/Ternary-Bonsai-27B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-gguf)
   - [prism-ml/Ternary-Bonsai-8B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-gguf)
   - [prism-ml/Ternary-Bonsai-4B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-gguf)
   - [prism-ml/Ternary-Bonsai-1.7B-gguf](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-gguf)
 - **MLX (2-bit)**:
+  - [prism-ml/Ternary-Bonsai-27B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit)
   - [prism-ml/Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
   - [prism-ml/Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
   - [prism-ml/Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)

--- a/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
@@ -33,6 +33,7 @@ find bin/ llama.cpp/ -name "llama-bench" -type f 2>/dev/null
 ### Ternary-Bonsai-27B (the one we most want numbers for!)
 
 ```bash
+# GPU (Metal / CUDA / Vulkan / ROCm) — adjust BENCH path (bin/mac, bin/cuda, bin/rocm, bin/vulkan, bin/cpu):
 BENCH=bin/mac/llama-bench
 $BENCH -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf -ngl 99 -fa 1
 ```

--- a/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
@@ -30,6 +30,15 @@ Run `./setup.sh` first, then find your `llama-bench` binary:
 find bin/ llama.cpp/ -name "llama-bench" -type f 2>/dev/null
 ```
 
+### Ternary-Bonsai-27B (the one we most want numbers for!)
+
+```bash
+BENCH=bin/mac/llama-bench
+$BENCH -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+(paste llama-bench output here, or remove this section if you skipped the 27B)
+
 ### Ternary-Bonsai-8B
 
 ```bash

--- a/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-mlx.md
+++ b/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-mlx.md
@@ -25,13 +25,24 @@
 ## MLX Results (2-bit)
 
 Ternary-Bonsai ships as MLX 2-bit out of the box:
+- [Ternary-Bonsai-27B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit)
 - [Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
 - [Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
 - [Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)
 
+### Ternary-Bonsai-27B (the one we most want numbers for!)
+
+```bash
+.venv/bin/python -m mlx_lm.benchmark --model models/Ternary-Bonsai-27B-mlx-2bit -p 512 -g 128
+```
+
+(paste MLX benchmark output here, or remove this section if you skipped the 27B)
+
 ### Ternary-Bonsai-8B
 
-<!-- TODO: Add MLX benchmark commands once script is finalized -->
+```bash
+.venv/bin/python -m mlx_lm.benchmark --model models/Ternary-Bonsai-8B-mlx-2bit -p 512 -g 128
+```
 
 (paste MLX benchmark output here — raw output, no code block)
 


### PR DESCRIPTION
Adds organized 27B results tables from the merged submissions (featured first), fills in the ternary results section, and adds 27B commands to all four templates.