### PR TITLE
readme: tested MLX runtime versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,20 @@ source .venv/bin/activate
 ./scripts/run_mlx.sh -p "What is the capital of France?"
 ```
 
+**Tested versions (reproducibility).** The released MLX weights are plain safetensors and need no runtime patches. The 1-bit packs need an MLX build with 1-bit quantization support: the [PrismML-Eng/mlx](https://github.com/PrismML-Eng/mlx) fork, branch `prism`, until [mlx#3161](https://github.com/ml-explore/mlx/pull/3161) merges upstream. The 2-bit ternary packs run on stock MLX. The released 27B packs were validated with:
+
+- Python 3.11
+- mlx fork branch `prism` at commit [`88c9c20`](https://github.com/PrismML-Eng/mlx/commit/88c9c205a50f)
+- `mlx-lm==0.31.2` (the version `setup.sh` pins)
+
+`setup.sh` builds the fork from the branch tip. To pin the exact validated runtime instead, clone and check out the commit before running setup; setup reuses an existing `./mlx` checkout:
+
+```bash
+git clone -b prism https://github.com/PrismML-Eng/mlx.git mlx
+git -C mlx checkout 88c9c20
+./setup.sh
+```
+
 ### Chat Server
 
 Start llama-server with its built-in chat UI:


### PR DESCRIPTION
Documents the validated MLX runtime (fork commit, mlx-lm pin, Python version) and how to pin it, answering #95.