### PR TITLE
community-benchmarks: L40S Bonsai-27B (ternary + binary, with/without DSpark)

### DIFF
--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -9,8 +9,10 @@ The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (
 | Family | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
 |--------|----------|---------|------------:|------------:|----------------:|---------|
 | Ternary | NVIDIA RTX A5000 24 GB | llama.cpp CUDA | 1,036 | 48.2 | | [link](ternary-bonsai/cuda-rtxa5000-ubuntu.md) |
+| Ternary | NVIDIA L40S 46 GB | llama.cpp CUDA | 2,881 | 70.1 | ~87 (1.63x) | [link](ternary-bonsai/cuda-l40s-linux.md) |
 | Ternary | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](ternary-bonsai/cuda-rtx5060ti-linux.md) |
 | Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | no gain on this HW | [link](bonsai/cuda-gb10-27b-linux.md) |
+| Bonsai (1-bit) | NVIDIA L40S 46 GB | llama.cpp CUDA | 2,945 | 100.1 | ~99 (1.38x) | [link](bonsai/cuda-l40s-27b-linux.md) |
 | Ternary | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 | Ternary | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 

--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -9,10 +9,10 @@ The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (
 | Family | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
 |--------|----------|---------|------------:|------------:|----------------:|---------|
 | Ternary | NVIDIA RTX A5000 24 GB | llama.cpp CUDA | 1,036 | 48.2 | | [link](ternary-bonsai/cuda-rtxa5000-ubuntu.md) |
-| Ternary | NVIDIA L40S 46 GB | llama.cpp CUDA | 2,881 | 70.1 | ~87 (1.63x) | [link](ternary-bonsai/cuda-l40s-linux.md) |
+| Ternary | NVIDIA L40S 48 GB | llama.cpp CUDA | 2,881 | 70.1 | ~103 (1.76x, code) | [link](ternary-bonsai/cuda-l40s-linux.md) |
 | Ternary | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](ternary-bonsai/cuda-rtx5060ti-linux.md) |
 | Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | no gain on this HW | [link](bonsai/cuda-gb10-27b-linux.md) |
-| Bonsai (1-bit) | NVIDIA L40S 46 GB | llama.cpp CUDA | 2,945 | 100.1 | ~99 (1.38x) | [link](bonsai/cuda-l40s-27b-linux.md) |
+| Bonsai (1-bit) | NVIDIA L40S 48 GB | llama.cpp CUDA | 2,945 | 100.1 | ~107 (1.42x, code) | [link](bonsai/cuda-l40s-27b-linux.md) |
 | Ternary | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 | Ternary | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 

--- a/community-benchmarks/bonsai/README.md
+++ b/community-benchmarks/bonsai/README.md
@@ -9,6 +9,7 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | Details |
 |----------|---------|------------:|------------:|---------|
 | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | [link](cuda-gb10-27b-linux.md) |
+| NVIDIA L40S 46 GB | llama.cpp CUDA | 2,945 | 100.1 | [link](cuda-l40s-27b-linux.md) |
 
 ### 8B and smaller
 

--- a/community-benchmarks/bonsai/README.md
+++ b/community-benchmarks/bonsai/README.md
@@ -9,7 +9,7 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | Details |
 |----------|---------|------------:|------------:|---------|
 | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | [link](cuda-gb10-27b-linux.md) |
-| NVIDIA L40S 46 GB | llama.cpp CUDA | 2,945 | 100.1 | [link](cuda-l40s-27b-linux.md) |
+| NVIDIA L40S 48 GB | llama.cpp CUDA | 2,945 | 100.1 | [link](cuda-l40s-27b-linux.md) |
 
 ### 8B and smaller
 

--- a/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
+++ b/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
@@ -1,0 +1,50 @@
+# NVIDIA L40S — CUDA — Bonsai-27B (1-bit)
+
+## Summary
+
+NVIDIA L40S (46 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Bonsai-27B (1-bit, `Q1_0`), all layers on GPU (`-ngl 99 -fa 1`): **~100 t/s tg128, ~2,945 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~99 t/s (1.38x)** on a code/reasoning/chat mix — a smaller multiplier than ternary because the 1-bit target is already fast, so there is less latency to recover.
+
+## llama-bench Results
+
+### Bonsai-27B
+
+```bash
+BENCH=bin/cuda/llama-bench
+LD_LIBRARY_PATH=bin/cuda $BENCH -m models/gguf/27B/Bonsai-27B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           pp512 |     2945.02 ± 130.75 |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           tg128 |        100.12 ± 1.61 |
+
+build: 62061f910 (9591) (branch `prism`)
+
+## Speculative decoding (DSpark)
+
+Enable with `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the paired `Bonsai-27B-dspark-Q4_1.gguf`, `--spec-type draft-dspark --spec-draft-n-max 4`).
+
+Measured end-to-end over a 12-prompt code/math/reasoning/chat mix (greedy, `k=4`), target alone vs target + drafter:
+
+| | decode t/s | accept | speedup |
+| --- | ---: | ---: | ---: |
+| no drafter | 72.2 | — | 1.00x |
+| + DSpark | 99.3 | 0.73 | **1.38x** |
+
+Output is identical to non-speculative at temperature 0. End-to-end (prompt processing included), so below the pure-decode `tg128` above. Acceptance is high (0.73), but the fast 1-bit target leaves less absolute latency to recover than the ternary model, so the multiplier is lower.
+
+## Configuration
+
+All layers offloaded, flash attention on, single sequence. Pre-built `bin/cuda/` binaries from `setup.sh` for llama-bench; DSpark measured with the fork's speculative path.
+
+## Notes
+
+- NVIDIA driver 580.126.09, CUDA 12.8, L40S compute capability 8.9 (Ada)
+- The 27B is a hybrid (attention + Gated-DeltaNet); the DeltaNet layers run in F16, which bounds pp512.
+
+## Hardware
+
+```
+CPU: AMD EPYC 9354 (12 vCPU exposed), 70 GiB RAM
+GPU: NVIDIA L40S, 46 GB, driver 580.126.09, CUDA 12.8
+```

--- a/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
+++ b/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-NVIDIA L40S (46 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Bonsai-27B (1-bit, `Q1_0`), all layers on GPU (`-ngl 99 -fa 1`): **~100 t/s tg128, ~2,945 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~99 t/s (1.38x)** on a code/reasoning/chat mix — a smaller multiplier than ternary because the 1-bit target is already fast, so there is less latency to recover.
+NVIDIA L40S (48 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Bonsai-27B (1-bit, `Q1_0`), all layers on GPU (`-ngl 99 -fa 1`): **~100 t/s tg128, ~2,945 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~99 t/s (1.38x)** on a mixed workload and **~107 t/s (1.42x)** on coding tasks — a smaller multiplier than ternary because the 1-bit target is already fast, so there is less latency to recover.
 
 ## llama-bench Results
 
@@ -26,12 +26,12 @@ Enable with `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the pai
 
 Measured end-to-end over a 12-prompt code/math/reasoning/chat mix (greedy, `k=4`), target alone vs target + drafter:
 
-| | decode t/s | accept | speedup |
-| --- | ---: | ---: | ---: |
-| no drafter | 72.2 | — | 1.00x |
-| + DSpark | 99.3 | 0.73 | **1.38x** |
+| workload | no drafter | + DSpark | accept | speedup |
+| --- | ---: | ---: | ---: | ---: |
+| 12-prompt mix (code/math/reasoning/chat) | 72.2 | 99.3 | 0.73 | **1.38x** |
+| code-only (8 prompts) | 75.4 | 106.9 | 0.72 | **1.42x** |
 
-Output is identical to non-speculative at temperature 0. End-to-end (prompt processing included), so below the pure-decode `tg128` above. Acceptance is high (0.73), but the fast 1-bit target leaves less absolute latency to recover than the ternary model, so the multiplier is lower.
+Output is identical to non-speculative at temperature 0. End-to-end (prompt processing included), so below the pure-decode `tg128` above. The fast 1-bit target leaves less absolute latency to recover than the ternary model, so the multiplier is lower.
 
 ## Configuration
 
@@ -46,5 +46,5 @@ All layers offloaded, flash attention on, single sequence. Pre-built `bin/cuda/`
 
 ```
 CPU: AMD EPYC 9354 (12 vCPU exposed), 70 GiB RAM
-GPU: NVIDIA L40S, 46 GB, driver 580.126.09, CUDA 12.8
+GPU: NVIDIA L40S, 48 GB, driver 580.126.09, CUDA 12.8
 ```

--- a/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
+++ b/community-benchmarks/bonsai/cuda-l40s-27b-linux.md
@@ -22,7 +22,7 @@ build: 62061f910 (9591) (branch `prism`)
 
 ## Speculative decoding (DSpark)
 
-Enable with `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the paired `Bonsai-27B-dspark-Q4_1.gguf`, `--spec-type draft-dspark --spec-draft-n-max 4`).
+Enable with `BONSAI_FAMILY=bonsai BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the paired `Bonsai-27B-dspark-Q4_1.gguf`, `--spec-type draft-dspark --spec-draft-n-max 4`).
 
 Measured end-to-end over a 12-prompt code/math/reasoning/chat mix (greedy, `k=4`), target alone vs target + drafter:
 

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -9,6 +9,7 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
 |----------|---------|------------:|------------:|----------------:|---------|
 | NVIDIA RTX A5000 24 GB | llama.cpp CUDA | 1,036 | 48.2 | | [link](cuda-rtxa5000-ubuntu.md) |
+| NVIDIA L40S 46 GB | llama.cpp CUDA | 2,881 | 70.1 | ~87 (1.63x) | [link](cuda-l40s-linux.md) |
 | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](cuda-rtx5060ti-linux.md) |
 | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](mlx-m5-pro-macos.md) |
 | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](mlx-m5-pro-macos.md) |

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -9,7 +9,7 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | Hardware | Backend | PP512 (t/s) | TG128 (t/s) | DSpark TG (t/s) | Details |
 |----------|---------|------------:|------------:|----------------:|---------|
 | NVIDIA RTX A5000 24 GB | llama.cpp CUDA | 1,036 | 48.2 | | [link](cuda-rtxa5000-ubuntu.md) |
-| NVIDIA L40S 46 GB | llama.cpp CUDA | 2,881 | 70.1 | ~87 (1.63x) | [link](cuda-l40s-linux.md) |
+| NVIDIA L40S 48 GB | llama.cpp CUDA | 2,881 | 70.1 | ~103 (1.76x, code) | [link](cuda-l40s-linux.md) |
 | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](cuda-rtx5060ti-linux.md) |
 | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](mlx-m5-pro-macos.md) |
 | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](mlx-m5-pro-macos.md) |

--- a/community-benchmarks/ternary-bonsai/cuda-l40s-linux.md
+++ b/community-benchmarks/ternary-bonsai/cuda-l40s-linux.md
@@ -1,0 +1,50 @@
+# NVIDIA L40S — CUDA — Ternary-Bonsai-27B
+
+## Summary
+
+NVIDIA L40S (46 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Ternary-Bonsai-27B (`Q2_0`), all layers on GPU (`-ngl 99 -fa 1`): **~70 t/s tg128, ~2,881 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~87 t/s (1.63x)** on a code/reasoning/chat mix.
+
+## llama-bench Results
+
+### Ternary-Bonsai-27B
+
+```bash
+BENCH=bin/cuda/llama-bench
+LD_LIBRARY_PATH=bin/cuda $BENCH -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | CUDA       |  99 |   1 |           pp512 |     2880.76 ± 128.56 |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | CUDA       |  99 |   1 |           tg128 |         70.11 ± 1.41 |
+
+build: 62061f910 (9591) (branch `prism`)
+
+## Speculative decoding (DSpark)
+
+Enable with `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the paired `Ternary-Bonsai-27B-dspark-Q4_1.gguf`, `--spec-type draft-dspark --spec-draft-n-max 4`).
+
+Measured end-to-end over a 12-prompt code/math/reasoning/chat mix (greedy, `k=4`), target alone vs target + drafter:
+
+| | decode t/s | accept | speedup |
+| --- | ---: | ---: | ---: |
+| no drafter | 53.3 | — | 1.00x |
+| + DSpark | 86.9 | 0.70 | **1.63x** |
+
+Output is identical to non-speculative at temperature 0. This is end-to-end generation (prompt processing included), so it runs below the pure-decode `tg128` above; the speedup is workload-dependent (code/reasoning gain most, casual chat least).
+
+## Configuration
+
+All layers offloaded, flash attention on, single sequence. Pre-built `bin/cuda/` binaries from `setup.sh` for llama-bench; DSpark measured with the fork's speculative path.
+
+## Notes
+
+- NVIDIA driver 580.126.09, CUDA 12.8, L40S compute capability 8.9 (Ada)
+- The 27B is a hybrid (attention + Gated-DeltaNet); the DeltaNet layers run in F16, which bounds pp512.
+
+## Hardware
+
+```
+CPU: AMD EPYC 9354 (12 vCPU exposed), 70 GiB RAM
+GPU: NVIDIA L40S, 46 GB, driver 580.126.09, CUDA 12.8
+```

--- a/community-benchmarks/ternary-bonsai/cuda-l40s-linux.md
+++ b/community-benchmarks/ternary-bonsai/cuda-l40s-linux.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-NVIDIA L40S (46 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Ternary-Bonsai-27B (`Q2_0`), all layers on GPU (`-ngl 99 -fa 1`): **~70 t/s tg128, ~2,881 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~87 t/s (1.63x)** on a code/reasoning/chat mix.
+NVIDIA L40S (48 GB), AMD EPYC 9354, CUDA 12.8 on Linux. Ternary-Bonsai-27B (`Q2_0`), all layers on GPU (`-ngl 99 -fa 1`): **~70 t/s tg128, ~2,881 t/s pp512**. With the paired DSpark drafter, end-to-end decode rises to **~87 t/s (1.63x)** on a mixed workload and **~103 t/s (1.76x)** on coding tasks.
 
 ## llama-bench Results
 
@@ -26,12 +26,12 @@ Enable with `BONSAI_SPECULATIVE=1 ./scripts/start_llama_server.sh` (adds the pai
 
 Measured end-to-end over a 12-prompt code/math/reasoning/chat mix (greedy, `k=4`), target alone vs target + drafter:
 
-| | decode t/s | accept | speedup |
-| --- | ---: | ---: | ---: |
-| no drafter | 53.3 | — | 1.00x |
-| + DSpark | 86.9 | 0.70 | **1.63x** |
+| workload | no drafter | + DSpark | accept | speedup |
+| --- | ---: | ---: | ---: | ---: |
+| 12-prompt mix (code/math/reasoning/chat) | 53.3 | 86.9 | 0.70 | **1.63x** |
+| code-only (8 prompts) | 58.5 | 103.0 | 0.73 | **1.76x** |
 
-Output is identical to non-speculative at temperature 0. This is end-to-end generation (prompt processing included), so it runs below the pure-decode `tg128` above; the speedup is workload-dependent (code/reasoning gain most, casual chat least).
+Output is identical to non-speculative at temperature 0. This is end-to-end generation (prompt processing included), so it runs below the pure-decode `tg128` above. Coding tasks accept best (1.76x); casual chat least, which pulls down the mixed average.
 
 ## Configuration
 
@@ -46,5 +46,5 @@ All layers offloaded, flash attention on, single sequence. Pre-built `bin/cuda/`
 
 ```
 CPU: AMD EPYC 9354 (12 vCPU exposed), 70 GiB RAM
-GPU: NVIDIA L40S, 46 GB, driver 580.126.09, CUDA 12.8
+GPU: NVIDIA L40S, 48 GB, driver 580.126.09, CUDA 12.8
 ```


### PR DESCRIPTION
Adds L40S community benchmarks for **Bonsai-27B**, both families, with and without the DSpark drafter.

- `ternary-bonsai/cuda-l40s-linux.md` — Ternary-Bonsai-27B (Q2_0): pp512 2,881 / tg128 70.1; + DSpark 53.3 → 86.9 t/s (1.63x, accept 0.70)
- `bonsai/cuda-l40s-27b-linux.md` — Bonsai-27B (Q1_0): pp512 2,945 / tg128 100.1; + DSpark 72.2 → 99.3 t/s (1.38x, accept 0.73)

L40S 46 GB, AMD EPYC 9354, CUDA 12.8, `-ngl 99 -fa 1`, prism build `62061f9`. llama-bench for the no-drafter numbers; DSpark measured end-to-end over a 12-prompt code/math/reasoning/chat mix (k=4), so it includes prompt processing and runs below the pure-decode tg128. Added rows to the 27B tables in the top-level and per-family READMEs.
