### PR TITLE
community-benchmarks: Apple M3 Pro 18 GB (Metal) — Ternary-Bonsai 27B/8B/4B/1.7B

### DIFF
--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -13,6 +13,7 @@ The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (
 | Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | no gain on this HW | [link](bonsai/cuda-gb10-27b-linux.md) |
 | Ternary | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 | Ternary | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
+| Ternary | Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](ternary-bonsai/metal-m3-pro-macos.md) |
 
 ## 8B and smaller
 
@@ -24,7 +25,7 @@ The 27B models come in two families: Bonsai (1-bit, `Q1_0`) and Ternary-Bonsai (
 | Bonsai (1-bit) | AMD Strix Halo 128 GB | llama.cpp ROCm HIP | 1,325 | 96 | [link](bonsai/rocm-hip-strix-halo-128gb-archlinux.md) |
 | Bonsai (1-bit) | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](bonsai/cuda-rtx3080-linux.md) |
 | Bonsai (1-bit) | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](bonsai/cuda-rtxa2000-debian.md) |
-| Ternary | *no submissions yet* | | | | |
+| Ternary | Apple M3 Pro 18 GB | llama.cpp Metal | 288 | 51.3 | [link](ternary-bonsai/metal-m3-pro-macos.md) |
 
 ## Model Families
 

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -12,14 +12,13 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](cuda-rtx5060ti-linux.md) |
 | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](mlx-m5-pro-macos.md) |
 | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](mlx-m5-pro-macos.md) |
+| Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](metal-m3-pro-macos.md) |
 
 ### 8B and smaller
 
-No submissions yet; be the first!
-
 | Hardware | Backend | 8B PP512 (t/s) | 8B TG128 (t/s) | Details |
 |----------|---------|---------------:|---------------:|---------|
-| | | | | |
+| Apple M3 Pro 18 GB | llama.cpp Metal | 288 | 51.3 | [link](metal-m3-pro-macos.md) |
 
 ## Available Formats
 

--- a/community-benchmarks/ternary-bonsai/metal-m3-pro-macos.md
+++ b/community-benchmarks/ternary-bonsai/metal-m3-pro-macos.md
@@ -1,0 +1,82 @@
+# Apple M3 Pro — Metal
+
+## Summary
+
+Apple M3 Pro (11-core CPU / 14-core GPU, 18 GB unified memory), macOS 26.5.2, llama.cpp Metal (pre-built binaries from `./setup.sh`, build 62061f910 (9591)). All four Ternary-Bonsai sizes fit comfortably in 18 GB. Headline numbers: 27B ~12.6 t/s tg128 (78.6 t/s pp512); 8B ~51.3 t/s tg128.
+
+## llama-bench Results
+
+### Ternary-Bonsai-27B
+
+```bash
+BENCH=bin/mac/llama-bench
+$BENCH -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | threads |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | ------: | --: | --------------: | -------------------: |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | MTL,BLAS   |       5 |   1 |           pp512 |         78.61 ± 0.09 |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | MTL,BLAS   |       5 |   1 |           tg128 |         12.61 ± 0.58 |
+
+build: 62061f910 (9591)
+
+### Ternary-Bonsai-8B
+
+```bash
+$BENCH -m models/ternary-gguf/8B/Ternary-Bonsai-8B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | threads |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | ------: | --: | --------------: | -------------------: |
+| qwen3 8B Q2_0                  |   2.03 GiB |     8.19 B | MTL,BLAS   |       5 |   1 |           pp512 |        287.82 ± 0.32 |
+| qwen3 8B Q2_0                  |   2.03 GiB |     8.19 B | MTL,BLAS   |       5 |   1 |           tg128 |         51.31 ± 0.41 |
+
+build: 62061f910 (9591)
+
+### Ternary-Bonsai-4B
+
+```bash
+$BENCH -m models/ternary-gguf/4B/Ternary-Bonsai-4B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | threads |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | ------: | --: | --------------: | -------------------: |
+| qwen3 4B Q2_0                  | 1019.50 MiB |     4.02 B | MTL,BLAS   |       5 |   1 |           pp512 |        532.38 ± 0.27 |
+| qwen3 4B Q2_0                  | 1019.50 MiB |     4.02 B | MTL,BLAS   |       5 |   1 |           tg128 |         83.41 ± 1.80 |
+
+build: 62061f910 (9591)
+
+### Ternary-Bonsai-1.7B
+
+```bash
+$BENCH -m models/ternary-gguf/1.7B/Ternary-Bonsai-1.7B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | threads |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | ------: | --: | --------------: | -------------------: |
+| qwen3 1.7B Q2_0                | 436.16 MiB |     1.72 B | MTL,BLAS   |       5 |   1 |           pp512 |       1348.77 ± 0.82 |
+| qwen3 1.7B Q2_0                | 436.16 MiB |     1.72 B | MTL,BLAS   |       5 |   1 |           tg128 |        164.56 ± 1.39 |
+
+build: 62061f910 (9591)
+
+## Configuration
+
+- Pre-built llama.cpp binaries downloaded by `./setup.sh` (`bin/mac`), default settings, `-ngl 99 -fa 1`.
+- MLX was not tested on this machine (Command Line Tools only, no full Xcode / Metal Toolchain).
+- 18 GB unified memory is the binned M3 Pro configuration (11-core CPU / 14-core GPU).
+
+## Notes
+
+- macOS 26.5.2 (Tahoe), Metal 4.
+- Machine was otherwise idle during the runs; variance across the 5 llama-bench repetitions was low (see ± columns).
+
+## Hardware
+
+```
+machdep.cpu.brand_string: Apple M3 Pro
+hw.memsize: 19327352832
+hw.ncpu: 11
+      Chipset Model: Apple M3 Pro
+      Total Number of Cores: 14
+      Metal Support: Metal 4
+```


### PR DESCRIPTION
## Summary

Community benchmark submission for **Apple M3 Pro (11-core CPU / 14-core GPU, 18 GB unified memory)**, macOS 26.5.2, llama.cpp **Metal** via the pre-built binaries from `./setup.sh` (build 62061f910 (9591)).

First M3-series entry, and the first row in the ternary "8B and smaller" table.

| Model | PP512 (t/s) | TG128 (t/s) |
|-------|------------:|------------:|
| Ternary-Bonsai-27B | 78.6 | 12.6 |
| Ternary-Bonsai-8B | 287.8 | 51.3 |
| Ternary-Bonsai-4B | 532.4 | 83.4 |
| Ternary-Bonsai-1.7B | 1348.8 | 164.6 |

All runs with `-ngl 99 -fa 1` per the template, machine otherwise idle, low variance across repetitions (raw llama-bench output in the details file).

## Changes

- Add `community-benchmarks/ternary-bonsai/metal-m3-pro-macos.md` (filled-in llama.cpp template, all four sizes)
- Add rows to the 27B and 8B-and-smaller tables in `community-benchmarks/README.md` and `community-benchmarks/ternary-bonsai/README.md`

MLX numbers not included — this machine has only Xcode CLT (no Metal Toolchain), so only the llama.cpp backend was benchmarked.
