### PR TITLE
readme/agents: document M5 Metal tensor-API failure on macOS 26 and its workaround (#93)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,9 @@ Full guide with entry examples: **TOOLS.md** (repo root). The essentials:
   conversation, image tokens included, on every turn), so follow-ups are much
   slower than llama.cpp (which caches the KV prefix). Steer multi-turn users to
   the llama.cpp backend; the image encoder itself is cached, it's the LM prefill.
+- **M5 Macs on macOS 26.2–26.4:** if Metal init fails with `error compiling source` /
+  command-buffer status 5, set `GGML_METAL_TENSOR_DISABLE=1` (README Appendix — FAQ has
+  details). Keep `-ngl` on GPU; don't reach for `BONSAI_NGL=0`.
 - Linux CUDA / Windows / CPU-only: not tested yet — extend these notes after testing.
 
 ## Quick verification commands

--- a/README.md
+++ b/README.md
@@ -538,3 +538,26 @@ Detected GPU VRAM: 8.0 GB (< 16 GB) -- limiting CUDA build to -j 2
 ```
 
 **Manual override:** If you still encounter OOM errors, reduce parallelism further by editing the build invocation in the relevant script, or close other GPU-heavy applications before building.
+
+### Metal fails to initialize on Apple M5 (macOS 26.2–26.4)
+
+**Symptom:** On M5 Macs, `run_llama.sh` / `start_llama_server.sh` fail with Metal errors and produce no output, e.g.:
+
+```
+ggml_metal_library_init_from_source: error compiling source
+ggml_metal_device_init: - the tensor API is not supported in this environment - disabling
+ggml_metal_synchronize: error: command buffer 0 failed with status 5
+```
+
+Pre-M5 Apple Silicon (M1–M4) is not affected — those devices load the embedded, precompiled Metal library and never compile shaders at runtime.
+
+**Cause:** On M5 (and A19) devices, ggml compiles its Metal library from source at runtime to enable the tensor API (Neural Accelerators). Some macOS 26 point releases ship stricter MetalPerformancePrimitives headers whose `static_assert` (bfloat/half type mismatch) breaks that runtime compile. This is an ecosystem-wide issue also seen in [ollama](https://github.com/ollama/ollama/issues/15594) and [whisper.cpp](https://github.com/ggml-org/whisper.cpp/issues/3722); see [#93](https://github.com/PrismML-Eng/Bonsai-demo/issues/93).
+
+**Workaround:** Disable the tensor API so the M5 uses the embedded library like pre-M5 devices — full Metal speed is kept, only the Neural Accelerator prefill boost is lost:
+
+```bash
+GGML_METAL_TENSOR_DISABLE=1 ./scripts/run_llama.sh -p "Hello"
+GGML_METAL_TENSOR_DISABLE=1 ./scripts/start_llama_server.sh
+```
+
+This is much faster than falling back to CPU (`BONSAI_NGL=0`). If out-of-memory errors persist afterwards on lower-memory machines, additionally pin a smaller context, e.g. `-c 16384` (extra args pass through to llama.cpp and override the auto-fit default).


### PR DESCRIPTION
## Summary

Follow-up to #93 (triage details in [this comment](https://github.com/PrismML-Eng/Bonsai-demo/issues/93#issuecomment-5009512152)).

On M5/A19 devices ggml compiles its Metal library from source at runtime to enable the tensor API (Neural Accelerators). Stricter MetalPerformancePrimitives headers in some macOS 26 point releases (26.2–26.4) break that compile with a bfloat/half `static_assert`, and inference then fails with command-buffer errors. Pre-M5 Apple Silicon loads the embedded precompiled metallib and is unaffected — verified on M3 Pro + macOS 26.5.2 with the pinned `prism-b9591-62061f9` binaries (#108). Same issue ecosystem-wide: [ollama#15594](https://github.com/ollama/ollama/issues/15594), [whisper.cpp#3722](https://github.com/ggml-org/whisper.cpp/issues/3722).

`GGML_METAL_TENSOR_DISABLE=1` (honored by the shipped `libggml-metal.dylib`) makes the M5 use the embedded library like pre-M5 devices — full Metal speed, only the tensor-API prefill boost lost. Much better than the `BONSAI_NGL=0` CPU fallback the reporter landed on.

## Changes

- **README.md** — new Appendix FAQ entry (same Symptom/Cause/Workaround format as the existing CUDA entry): failure signature, why only M5 is affected, the env-var workaround, and the follow-up `-c` hint for OOM on lower-memory machines.
- **AGENTS.md** — one bullet in "Behavior notes (Apple Silicon)" so agents reach for the env var instead of dropping users to CPU.

Docs only — no script changes. Auto-setting the env var in the run scripts would penalize M5 setups where the tensor API works (it was tested fine on some M5 machines), so this keeps it a user-visible, user-controlled knob. Happy to wire version-gated auto-detection into the scripts instead if you'd prefer that direction.

Closes #93 (if the maintainers consider docs sufficient until the upstream header issue is resolved).