### PR TITLE
deps: cap requires-python below 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "bonsai-demo"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.13"
 dependencies = [
     "huggingface-hub>=1.5.0",
     "cmake",


### PR DESCRIPTION
open-webui 0.10.2 depends on pydub which needs stdlib audioop, removed in Python 3.13. setup.sh already creates a 3.11 venv, but manual installs into 3.13+ environments hit a runtime ModuleNotFoundError; the cap turns that into a clear installer error. Fixes #115.