### PR TITLE
fix fallback CUDA version detection for latest nvidia drivers

### DIFF
--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -42,7 +42,7 @@ case "$OS" in
         if command -v nvcc >/dev/null 2>&1; then
             _cuda_ver=$(nvcc --version 2>/dev/null | sed -n 's/.*release \([0-9]*\.[0-9]*\).*/\1/p')
         elif command -v nvidia-smi >/dev/null 2>&1; then
-            _cuda_ver=$(nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version:[[:space:]]*\([0-9]*\.[0-9]*\).*/\1/p')
+            _cuda_ver=$(nvidia-smi 2>/dev/null | sed -n 's/.*CUDA[ A-Z]*Version:[[:space:]]*\([0-9]*\.[0-9]*\).*/\1/p')
         fi
 
         if [ -n "$_cuda_ver" ]; then


### PR DESCRIPTION
New versions of nvidia-smi use "CUDA UMD Version" label instead of the "CUDA Version".

It was deprecated in `nvidia-smi -q`: [Deprecated; will be removed in CUDA 14.0. Use CUDA UMD Version instead]

And entirely removed from the `nvidia-smi` as of NVIDIA-SMI 610.43.03, not sure when the change happened exactly, though.

Backwards compatible with older versions.

Ref: [https://docs.nvidia.com/deploy/nvidia-smi/index.html](https://docs.nvidia.com/deploy/nvidia-smi/index.html):

> Modified version information: deprecated Driver Version and CUDA Version in favor of KMD Version and CUDA UMD Version respectively to more accurately reflect the source of the version information.