### PR TITLE
Add BONSAI_SKIP_GGUF and auto-fallback to MLX when GGUF is absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Both variables are optional. **If you set neither, the default is `Ternary-Bonsa
 | `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all`         | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
 | `BONSAI_MODEL`  | `27B`    | `27B`, `8B`, `4B`, `1.7B`, `all`   | Model size. `all` expands to all four sizes (setup/download only). |
 | `BONSAI_TOKEN`  | —        | HF read-only token                 | Only needed for the 27B models while their repos are private (removed at launch). |
-| `BONSAI_SKIP_GGUF` | unset  | `1`                                 | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). `run_llama.sh` / `start_llama_server.sh` then auto-fall back to the MLX backend (see "Running the Model" below). |
+| `BONSAI_SKIP_GGUF` | unset  | `1`                                 | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
 | `BONSAI_SKIP_MLX`  | unset  | `1`                                 | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
 
 `all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size.
@@ -243,12 +243,10 @@ All run scripts respect `BONSAI_MODEL` (default `27B`). Set it to run a differen
 BONSAI_MODEL=4B ./scripts/run_llama.sh -p "Write a haiku about bonsai trees"
 ```
 
-On macOS, if no GGUF model is downloaded (e.g. you set `BONSAI_SKIP_GGUF=1`) but an
-MLX model is present, `run_llama.sh` / `start_llama_server.sh` automatically fall back
-to the MLX backend (`run_mlx.sh` / `start_mlx_server.sh`) instead of failing. A warning
-is printed when this happens — llama.cpp-only flags (`-ngl`, `-c`, `-fa`, `--jinja`,
-...) don't apply to MLX and may be ignored or rejected, and the server fallback listens
-on port **8081**, not 8080.
+These scripts run the llama.cpp backend and need GGUF weights. On an MLX-only setup
+(e.g. you used `BONSAI_SKIP_GGUF=1`), they stop with an error that points at both
+options — running the MLX script directly (`run_mlx.sh` / `start_mlx_server.sh`), or
+downloading the GGUF weights.
 
 ### llama.cpp (Windows PowerShell)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Both variables are optional. **If you set neither, the default is `Ternary-Bonsa
 | `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all`         | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
 | `BONSAI_MODEL`  | `27B`    | `27B`, `8B`, `4B`, `1.7B`, `all`   | Model size. `all` expands to all four sizes (setup/download only). |
 | `BONSAI_TOKEN`  | —        | HF read-only token                 | Only needed for the 27B models while their repos are private (removed at launch). |
+| `BONSAI_SKIP_GGUF` | unset  | `1`                                 | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). `run_llama.sh` / `start_llama_server.sh` then auto-fall back to the MLX backend (see "Running the Model" below). |
+| `BONSAI_SKIP_MLX`  | unset  | `1`                                 | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
 
 `all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size.
 
@@ -163,6 +165,7 @@ BONSAI_FAMILY=bonsai ./setup.sh                             # Bonsai-27B (1-bit)
 BONSAI_FAMILY=bonsai BONSAI_MODEL=4B ./setup.sh             # Bonsai-4B
 BONSAI_MODEL=all ./setup.sh                                 # All 4 Ternary-Bonsai sizes
 BONSAI_FAMILY=all BONSAI_MODEL=all ./setup.sh               # Full matrix (8 downloads)
+BONSAI_FAMILY=bonsai BONSAI_SKIP_GGUF=1 ./setup.sh          # Bonsai-27B, MLX only (macOS, saves disk space)
 ```
 
 ## Upstream Status for Binary
@@ -239,6 +242,13 @@ All run scripts respect `BONSAI_MODEL` (default `27B`). Set it to run a differen
 # Run a different model size
 BONSAI_MODEL=4B ./scripts/run_llama.sh -p "Write a haiku about bonsai trees"
 ```
+
+On macOS, if no GGUF model is downloaded (e.g. you set `BONSAI_SKIP_GGUF=1`) but an
+MLX model is present, `run_llama.sh` / `start_llama_server.sh` automatically fall back
+to the MLX backend (`run_mlx.sh` / `start_mlx_server.sh`) instead of failing. A warning
+is printed when this happens — llama.cpp-only flags (`-ngl`, `-c`, `-fa`, `--jinja`,
+...) don't apply to MLX and may be ignored or rejected, and the server fallback listens
+on port **8081**, not 8080.
 
 ### llama.cpp (Windows PowerShell)
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -88,15 +88,38 @@ bonsai_mlx_present() {
     [ -f "$MLX_MODEL_DIR/config.json" ]
 }
 
-# Check GGUF model is downloaded — prompts to download if missing
+# True if the MLX model is present AND this machine can actually run it.
+# MLX is Apple Silicon only, so an Intel Mac that happens to have MLX weights
+# (copied over, or downloaded with BONSAI_SKIP_MLX=0) must not be pointed at
+# the MLX scripts.
+bonsai_mlx_usable() {
+    [ "$(uname -s)" = "Darwin" ] || return 1
+    [ "$(uname -m)" = "arm64" ] || return 1
+    bonsai_mlx_present
+}
+
+# Check GGUF model is downloaded — prompts to download if missing.
+# Optional $1: the MLX script this caller has an equivalent of (e.g.
+# "run_mlx.sh"). When the GGUF is missing but a usable MLX model is already
+# downloaded, the error also points at that script, so an MLX-only setup
+# (BONSAI_SKIP_GGUF=1) gets told what to run instead of only being told to
+# download several GB it may not want.
 assert_gguf_downloaded() {
     _assert_concrete_model
-    if ! bonsai_gguf_present; then
-        err "GGUF model not found for ${BONSAI_DISPLAY} (expected in ${GGUF_MODEL_DIR}/)."
+    bonsai_gguf_present && return 0
+
+    err "GGUF model not found for ${BONSAI_DISPLAY} (expected in ${GGUF_MODEL_DIR}/)."
+    if [ -n "${1:-}" ] && bonsai_mlx_usable; then
+        echo "  An MLX model for ${BONSAI_DISPLAY} is already downloaded. Either:"
+        echo "    - run the MLX backend directly:"
+        echo "        BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/$1"
+        echo "    - or download the GGUF weights for the llama.cpp backend:"
+        echo "        BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
+    else
         echo "  Download it with:"
         echo "    BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
-        exit 1
     fi
+    exit 1
 }
 
 # Check MLX model is downloaded — prompts to download if missing
@@ -107,26 +130,6 @@ assert_mlx_downloaded() {
         echo "  Download it with:"
         echo "    BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
         exit 1
-    fi
-}
-
-# If the GGUF model is missing but the MLX model is present (Apple Silicon),
-# exec the MLX equivalent of the calling script instead of failing outright --
-# lets run_llama.sh / start_llama_server.sh "just work" on a BONSAI_SKIP_GGUF=1
-# / MLX-only setup. $1 is the MLX script to exec (relative to SCRIPT_DIR, which
-# the caller must have already set); the remaining args are forwarded as-is.
-# Returns normally (no exec) when GGUF is present, or when there's no MLX
-# fallback either -- the caller's own assert_gguf_downloaded then reports the
-# real error.
-bonsai_maybe_dispatch_to_mlx() {
-    _assert_concrete_model
-    _mlx_script="$1"
-    shift
-    bonsai_gguf_present && return 0
-    if [ "$(uname -s)" = "Darwin" ] && bonsai_mlx_present; then
-        warn "No GGUF model found for ${BONSAI_DISPLAY}; falling back to the MLX backend (scripts/${_mlx_script})."
-        echo "  llama.cpp-only flags (-ngl, -c, -fa, --jinja, ...) do not apply to MLX and may be ignored or rejected."
-        exec "$SCRIPT_DIR/$_mlx_script" "$@"
     fi
 }
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -71,10 +71,27 @@ _assert_concrete_model() {
     fi
 }
 
+# True if the concrete GGUF file for the current family/size is present
+# (matching GGUF_QUANT_PATTERN, excluding the mmproj/dspark/kv-bias extras --
+# same filter run_llama.sh / start_llama_server.sh use to pick MODEL).
+bonsai_gguf_present() {
+    for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
+        [ -f "$_m" ] || continue
+        case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
+        return 0
+    done
+    return 1
+}
+
+# True if the MLX model for the current family/size is present.
+bonsai_mlx_present() {
+    [ -f "$MLX_MODEL_DIR/config.json" ]
+}
+
 # Check GGUF model is downloaded — prompts to download if missing
 assert_gguf_downloaded() {
     _assert_concrete_model
-    if ! ls "$GGUF_MODEL_DIR"/*.gguf >/dev/null 2>&1; then
+    if ! bonsai_gguf_present; then
         err "GGUF model not found for ${BONSAI_DISPLAY} (expected in ${GGUF_MODEL_DIR}/)."
         echo "  Download it with:"
         echo "    BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
@@ -85,11 +102,31 @@ assert_gguf_downloaded() {
 # Check MLX model is downloaded — prompts to download if missing
 assert_mlx_downloaded() {
     _assert_concrete_model
-    if [ ! -f "$MLX_MODEL_DIR/config.json" ]; then
+    if ! bonsai_mlx_present; then
         err "MLX model not found for ${BONSAI_DISPLAY} (expected in ${MLX_MODEL_DIR}/)."
         echo "  Download it with:"
         echo "    BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
         exit 1
+    fi
+}
+
+# If the GGUF model is missing but the MLX model is present (Apple Silicon),
+# exec the MLX equivalent of the calling script instead of failing outright --
+# lets run_llama.sh / start_llama_server.sh "just work" on a BONSAI_SKIP_GGUF=1
+# / MLX-only setup. $1 is the MLX script to exec (relative to SCRIPT_DIR, which
+# the caller must have already set); the remaining args are forwarded as-is.
+# Returns normally (no exec) when GGUF is present, or when there's no MLX
+# fallback either -- the caller's own assert_gguf_downloaded then reports the
+# real error.
+bonsai_maybe_dispatch_to_mlx() {
+    _assert_concrete_model
+    _mlx_script="$1"
+    shift
+    bonsai_gguf_present && return 0
+    if [ "$(uname -s)" = "Darwin" ] && bonsai_mlx_present; then
+        warn "No GGUF model found for ${BONSAI_DISPLAY}; falling back to the MLX backend (scripts/${_mlx_script})."
+        echo "  llama.cpp-only flags (-ngl, -c, -fa, --jinja, ...) do not apply to MLX and may be ignored or rejected."
+        exec "$SCRIPT_DIR/$_mlx_script" "$@"
     fi
 }
 
@@ -214,6 +251,16 @@ bonsai_should_skip_mlx() {
         *)
             [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ] && return 0
             return 1 ;;
+    esac
+}
+
+# GGUF is downloaded by default (needed for the llama.cpp backend); skip it
+# with BONSAI_SKIP_GGUF=1 when you only intend to run the MLX backend and
+# want to save disk space / download time.
+bonsai_should_skip_gguf() {
+    case "${BONSAI_SKIP_GGUF:-}" in
+        1|true|yes) return 0 ;;
+        *) return 1 ;;
     esac
 }
 

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -9,9 +9,14 @@
 #   BONSAI_MODEL=all ./scripts/download_models.sh                        # All sizes of the selected family
 #   BONSAI_FAMILY=all ./scripts/download_models.sh                       # Both families, 27B size
 #   BONSAI_FAMILY=all BONSAI_MODEL=all ./scripts/download_models.sh      # Full matrix (8 downloads)
+#   BONSAI_SKIP_GGUF=1 ./scripts/download_models.sh                      # MLX only (macOS) — saves disk space
 #
 # Set BONSAI_TOKEN (a read-only HF token) if you need to pull a repo that is
 # still private; public repos download anonymously with no token.
+#
+# Set BONSAI_SKIP_GGUF=1 to skip the GGUF download entirely (llama.cpp backend
+# won't be usable afterwards — only makes sense if you only run the MLX
+# backend on Apple Silicon). Set BONSAI_SKIP_MLX=1 for the inverse.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -120,33 +125,37 @@ download_one() {
     # (not just any *.gguf) so a leftover F16 or other quant from an earlier
     # download doesn't get picked up at runtime. For 27B the fast-path also
     # requires the mmproj and drafter so a re-run backfills vision + speculative.
-    _gguf_present=false
-    if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
-        if { [ -z "$_mmproj_pattern" ] || ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; } \
-            && { [ -z "$_drafter_pattern" ] || ls "$_gguf_dir"/$_drafter_pattern >/dev/null 2>&1; }; then
-            _gguf_present=true
-        fi
-    fi
-    if [ "$_gguf_present" = true ]; then
-        info "GGUF ${_display} (${_gguf_pattern}) already present in ${_gguf_dir}/"
+    if bonsai_should_skip_gguf; then
+        info "Skipping GGUF ${_display} (BONSAI_SKIP_GGUF=1)."
     else
-        step "Downloading GGUF ${_display} (${_dl_patterns}) from ${_gguf_repo} ..."
-        mkdir -p "$_gguf_dir"
-        if ! hf_download "$_gguf_repo" "$_gguf_dir" "$_dl_patterns"; then
-            err "Failed to download GGUF ${_display} from ${_gguf_repo}."
-            exit 1
+        _gguf_present=false
+        if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
+            if { [ -z "$_mmproj_pattern" ] || ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; } \
+                && { [ -z "$_drafter_pattern" ] || ls "$_gguf_dir"/$_drafter_pattern >/dev/null 2>&1; }; then
+                _gguf_present=true
+            fi
         fi
-        if ! ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
-            err "Download reported success but no file matching ${_gguf_pattern} was written to ${_gguf_dir}/."
-            exit 1
+        if [ "$_gguf_present" = true ]; then
+            info "GGUF ${_display} (${_gguf_pattern}) already present in ${_gguf_dir}/"
+        else
+            step "Downloading GGUF ${_display} (${_dl_patterns}) from ${_gguf_repo} ..."
+            mkdir -p "$_gguf_dir"
+            if ! hf_download "$_gguf_repo" "$_gguf_dir" "$_dl_patterns"; then
+                err "Failed to download GGUF ${_display} from ${_gguf_repo}."
+                exit 1
+            fi
+            if ! ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
+                err "Download reported success but no file matching ${_gguf_pattern} was written to ${_gguf_dir}/."
+                exit 1
+            fi
+            if [ -n "$_mmproj_pattern" ] && ! ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; then
+                warn "No ${_mmproj_pattern} file in ${_gguf_repo} — image input will be disabled for ${_display}."
+            fi
+            if [ -n "$_drafter_pattern" ] && ! ls "$_gguf_dir"/$_drafter_pattern >/dev/null 2>&1; then
+                warn "No ${_drafter_pattern} file in ${_gguf_repo}; speculative decoding (BONSAI_SPECULATIVE=1) will be unavailable for ${_display}."
+            fi
+            info "GGUF ${_display} downloaded to ${_gguf_dir}/"
         fi
-        if [ -n "$_mmproj_pattern" ] && ! ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; then
-            warn "No ${_mmproj_pattern} file in ${_gguf_repo} — image input will be disabled for ${_display}."
-        fi
-        if [ -n "$_drafter_pattern" ] && ! ls "$_gguf_dir"/$_drafter_pattern >/dev/null 2>&1; then
-            warn "No ${_drafter_pattern} file in ${_gguf_repo}; speculative decoding (BONSAI_SPECULATIVE=1) will be unavailable for ${_display}."
-        fi
-        info "GGUF ${_display} downloaded to ${_gguf_dir}/"
     fi
 
     # MLX (macOS Apple Silicon only; skipped on Intel or when BONSAI_SKIP_MLX=1)

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -8,8 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 assert_valid_model
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
-bonsai_maybe_dispatch_to_mlx run_mlx.sh "$@"
-assert_gguf_downloaded
+assert_gguf_downloaded run_mlx.sh
 
 # ── Find model: select exactly the demo quant for the family ──
 MODEL=""

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 assert_valid_model
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
+bonsai_maybe_dispatch_to_mlx run_mlx.sh "$@"
 assert_gguf_downloaded
 
 # ── Find model: select exactly the demo quant for the family ──

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 assert_valid_model
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
+bonsai_maybe_dispatch_to_mlx start_mlx_server.sh "$@"
 assert_gguf_downloaded
 
 # Bind to localhost by default; override with BONSAI_HOST=0.0.0.0 for LAN/remote.

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -9,8 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 assert_valid_model
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
-bonsai_maybe_dispatch_to_mlx start_mlx_server.sh "$@"
-assert_gguf_downloaded
+assert_gguf_downloaded start_mlx_server.sh
 
 # Bind to localhost by default; override with BONSAI_HOST=0.0.0.0 for LAN/remote.
 HOST="${BONSAI_HOST:-127.0.0.1}"


### PR DESCRIPTION
## Summary
- Add `BONSAI_SKIP_GGUF=1` to `download_models.sh` so an MLX-only Apple Silicon setup can skip the (large) GGUF download entirely and save disk space, mirroring the existing `BONSAI_SKIP_MLX`.
- `run_llama.sh` / `start_llama_server.sh` no longer hard-fail when no GGUF is present: if an MLX model is available on macOS, they transparently `exec` into `run_mlx.sh` / `start_mlx_server.sh` instead, with a warning that llama.cpp-only flags (`-ngl`, `-c`, `-fa`, `--jinja`, ...) don't apply to MLX and that the server fallback listens on port 8081, not 8080.
- Document both in the README (env var table + a note in the "Running the Model" section).

## Test plan
- [x] `sh -n scripts/common.sh scripts/download_models.sh scripts/run_llama.sh scripts/start_llama_server.sh` — all parse.
- [x] Sandbox test: GGUF missing + MLX `config.json` present on Darwin → `run_llama.sh` prints the fallback warning and execs into `run_mlx.sh`.
- [x] Sandbox test: GGUF missing + MLX also missing → original "GGUF model not found" error is unchanged.
- [x] Real hardware (Mac Mini, Apple Silicon, 16 GB RAM) — all four affected paths, details in PR comments:
  - [x] `BONSAI_SKIP_GGUF=1 ./setup.sh` downloaded MLX weights only; `models/gguf/27B/` never created.
  - [x] `run_llama.sh` with no GGUF → fallback warning, dispatched to `run_mlx.sh`, generated correctly (~21.5 t/s, 4.15-4.29 GB peak).
  - [x] `start_llama_server.sh` with no GGUF → fallback warning, dispatched to `start_mlx_server.sh`, served correctly on :8081 over the OpenAI-compatible API.
  - [x] Open WebUI (`BONSAI_BACKEND=mlx`) works end to end against the same MLX-only setup on :9090.