### PR TITLE
openwebui: nudge toward BONSAI_BACKEND=mlx when GGUF is missing but MLX is usable

### DIFF
--- a/OPENWEBUI.md
+++ b/OPENWEBUI.md
@@ -18,6 +18,8 @@ Prefer the MLX backend on a Mac? Same thing with:
 BONSAI_BACKEND=mlx ./scripts/start_openwebui.sh
 ```
 
+On an MLX-only setup (you ran `BONSAI_SKIP_GGUF=1`), the default llama.cpp backend has no GGUF to load, so a plain `./scripts/start_openwebui.sh` stops with an error pointing you at this `BONSAI_BACKEND=mlx` command.
+
 It always runs exactly one backend (two resident 27Bs is too heavy for most machines). Note the MLX backend is noticeably slower per token and takes longer to first response on a fresh chat. It also has no cross-request prompt cache, so each follow-up re-processes the whole conversation (including image tokens), so multi-turn chats are slower than on llama.cpp, which caches the prefix. For interactive multi-turn use, prefer the default llama.cpp backend.
 
 ## What to try

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -98,12 +98,17 @@ bonsai_mlx_usable() {
     bonsai_mlx_present
 }
 
-# Check GGUF model is downloaded — prompts to download if missing.
-# Optional $1: the MLX script this caller has an equivalent of (e.g.
-# "run_mlx.sh"). When the GGUF is missing but a usable MLX model is already
-# downloaded, the error also points at that script, so an MLX-only setup
-# (BONSAI_SKIP_GGUF=1) gets told what to run instead of only being told to
-# download several GB it may not want.
+# Check the GGUF model is downloaded; error out with a download hint if not.
+#
+# The two optional args let the error also offer the MLX backend when the GGUF
+# is missing but a usable MLX model is already on disk (the BONSAI_SKIP_GGUF=1
+# case) — so the user is told what they *can* run now, not just to download
+# several GB of GGUF they may not want:
+#   $1  MLX-equivalent script to suggest, e.g. "run_mlx.sh"
+#   $2  env prefix, for callers where the MLX path is the *same* script driven
+#       by an env var instead of a separate one, e.g. "BONSAI_BACKEND=mlx"
+# Callers with no MLX equivalent (e.g. make_kv_bias.sh) pass nothing and get the
+# plain "download the GGUF" message.
 assert_gguf_downloaded() {
     _assert_concrete_model
     bonsai_gguf_present && return 0
@@ -112,7 +117,7 @@ assert_gguf_downloaded() {
     if [ -n "${1:-}" ] && bonsai_mlx_usable; then
         echo "  An MLX model for ${BONSAI_DISPLAY} is already downloaded. Either:"
         echo "    - run the MLX backend directly:"
-        echo "        BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/$1"
+        echo "        BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ${2:+$2 }./scripts/$1"
         echo "    - or download the GGUF weights for the llama.cpp backend:"
         echo "        BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL} ./scripts/download_models.sh"
     else

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -49,7 +49,9 @@ esac
 if [ "$BONSAI_BACKEND" = "mlx" ]; then
     assert_mlx_downloaded
 else
-    assert_gguf_downloaded
+    # Default llama backend. If the GGUF is missing but MLX is usable, the hint
+    # is to re-run with BONSAI_BACKEND=mlx (same script), not to fetch the GGUF.
+    assert_gguf_downloaded start_openwebui.sh BONSAI_BACKEND=mlx
 fi
 
 DEMO_DIR="$(resolve_demo_dir)"


### PR DESCRIPTION
Follow-up to #123 — the open question I raised there:

> `start_openwebui.sh` also calls `assert_gguf_downloaded` with no argument, and its natural hint would be `BONSAI_BACKEND=mlx` rather than a script name.

@khosravipasha suggested a separate PR for it, so here it is.

## What

`start_openwebui.sh` selects its backend with `BONSAI_BACKEND` (default `llama`). On an MLX-only install (`BONSAI_SKIP_GGUF=1`), the right fix for a missing GGUF is to re-run with `BONSAI_BACKEND=mlx` — *not* to download several GB of GGUF. But it called `assert_gguf_downloaded` with no argument, so the user got the plain "download the GGUF" message.

## How

`assert_gguf_downloaded` gets an optional **second** arg: an env-var prefix for the MLX suggestion, for callers where the MLX path is the *same* script driven by an env var rather than a separate script.

- `start_openwebui.sh` now calls `assert_gguf_downloaded start_openwebui.sh BONSAI_BACKEND=mlx`
- `run_llama.sh` / `start_llama_server.sh` pass no prefix, so their output is **byte-identical** to before
- No-arg callers (`make_kv_bias.sh`) keep the plain download message

New error on an MLX-only box:

```
[ERR]  GGUF model not found for Bonsai-27B (expected in models/gguf/27B/).
  An MLX model for Bonsai-27B is already downloaded. Either:
    - run the MLX backend directly:
        BONSAI_FAMILY=bonsai BONSAI_MODEL=27B BONSAI_BACKEND=mlx ./scripts/start_openwebui.sh
    - or download the GGUF weights for the llama.cpp backend:
        BONSAI_FAMILY=bonsai BONSAI_MODEL=27B ./scripts/download_models.sh
```

The suggestion stays gated on `bonsai_mlx_usable` (Darwin + arm64 + weights present), so an Intel Mac with stale MLX files is never pointed at MLX. Documented in OPENWEBUI.md next to the `BONSAI_BACKEND=mlx` invocation.

## Testing

Tested on real hardware (M4 Max, macOS arm64) against an MLX-only checkout — Bonsai-27B MLX present, no GGUF on disk:

| Scenario | Result |
|---|---|
| `start_openwebui.sh`, default backend, no GGUF | Errors with the new `BONSAI_BACKEND=mlx` nudge, exit 1 |
| `run_llama.sh` / `start_llama_server.sh` (no env prefix) | Output byte-identical to before — no regression |
| No-arg caller (`make_kv_bias.sh`) | Plain "download the GGUF" message, unchanged |
| Intel Mac simulated (`uname -m` = x86_64) + MLX present | MLX suggestion correctly withheld |
| **End-to-end:** `BONSAI_BACKEND=mlx ./scripts/start_openwebui.sh` | Full demo boots — MLX server (:8081) + Open WebUI (:9090, `/health` 200), real generation returned "Paris", clean teardown (all ports freed) |

`sh -n` passes on all changed scripts.