### PR TITLE
fix: windows cuda build is missing few dlls

### DIFF
--- a/scripts/build_cuda_windows.ps1
+++ b/scripts/build_cuda_windows.ps1
@@ -147,7 +147,7 @@ if ($copied.Count -eq 0) { Write-Host "  [WARN] no llama-*.exe found to copy" -F
 # ── Copy DLLs ──
 Write-Host ""
 Write-Host "=== Copying shared libraries ===" -ForegroundColor Cyan
-$dllPatterns = @("llama.dll", "ggml*.dll")
+$dllPatterns = @("llama.dll", "ggml*.dll", "llama-*.dll", "mtmd.dll")
 foreach ($pattern in $dllPatterns) {
     $releasePath = Join-Path $RepoDir "$BuildDir\bin\Release"
     $binPath = Join-Path $RepoDir "$BuildDir\bin"


### PR DESCRIPTION
Just few dlls were missing after running `scripts/build_cuda_windows.ps1`