### PR TITLE
Add GTX 1080 Ti CUDA benchmark results (Bonsai + Ternary-Bonsai, all sizes)

### DIFF
--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -16,9 +16,11 @@ Sorted by decode speed (TG128). The 27B models come in two families: Bonsai (1-b
 | Ternary | NVIDIA RTX 5060 Ti 16 GB | llama.cpp CUDA | 1,029 | 44.4 | ~79 (1.78x) | [link](ternary-bonsai/cuda-rtx5060ti-linux.md) |
 | Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | no gain on this HW | [link](bonsai/cuda-gb10-27b-linux.md) |
 | Ternary | Apple M5 Pro 64 GB | MLX 2-bit | 466 | 29.5 | 34-49 (community dspark-mlx) | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
+| Bonsai (1-bit) | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 285 | 28.3 | | [link](bonsai/cuda-gtx1080ti-linux.md) |
 | Ternary | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](ternary-bonsai/mlx-m5-pro-macos.md) |
 | Ternary | Apple M4 Pro 64 GB | MLX 2-bit | 120 | 24.8 | | [link](ternary-bonsai/mlx-m4-pro-64gb-macos.md) |
 | Ternary | Apple M4 Pro 64 GB | llama.cpp Metal | 116 | 19.0 | slower on this HW | [link](ternary-bonsai/metal-m4-pro-64gb-macos.md) |
+| Ternary | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 278 | 20.5 | | [link](ternary-bonsai/cuda-gtx1080ti-linux.md) |
 | Ternary | Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](ternary-bonsai/metal-m3-pro-macos.md) |
 
 ## 8B and smaller
@@ -29,7 +31,9 @@ Sorted by decode speed (TG128). The 27B models come in two families: Bonsai (1-b
 | Bonsai (1-bit) | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](bonsai/cuda-rtx3080-linux.md) |
 | Bonsai (1-bit) | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 3,978 | 159 | [link](bonsai/cuda-gb10-linux.md) |
 | Bonsai (1-bit) | Apple M4 Pro 48 GB | llama.cpp Metal | 487 | 117 | [link](bonsai/metal-m4-pro-48gb-macos.md) |
+| Bonsai (1-bit) | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 1,008 | 101.2 | [link](bonsai/cuda-gtx1080ti-linux.md) |
 | Bonsai (1-bit) | AMD Strix Halo 128 GB | llama.cpp ROCm HIP | 1,325 | 96 | [link](bonsai/rocm-hip-strix-halo-128gb-archlinux.md) |
+| Ternary | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 985 | 68.8 | [link](ternary-bonsai/cuda-gtx1080ti-linux.md) |
 | Bonsai (1-bit) | AMD Strix Halo 128 GB | llama.cpp Vulkan | 831 | 64 | [link](bonsai/vulkan-strix-halo-128gb-archlinux.md) |
 | Bonsai (1-bit) | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](bonsai/cuda-rtxa2000-debian.md) |
 | Ternary | Apple M3 Pro 18 GB | llama.cpp Metal | 288 | 51.3 | [link](ternary-bonsai/metal-m3-pro-macos.md) |

--- a/community-benchmarks/bonsai/README.md
+++ b/community-benchmarks/bonsai/README.md
@@ -10,6 +10,7 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 |----------|---------|------------:|------------:|---------|
 | NVIDIA L40S 48 GB | llama.cpp CUDA | 2,945 | 100.1 | [link](cuda-l40s-27b-linux.md) |
 | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 1,003 | 44.1 | [link](cuda-gb10-27b-linux.md) |
+| NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 285 | 28.3 | [link](cuda-gtx1080ti-linux.md) |
 
 ### 8B and smaller
 
@@ -18,6 +19,7 @@ Benchmark results submitted by the community running [Bonsai](https://huggingfac
 | NVIDIA GeForce RTX 3080 10 GB | llama.cpp CUDA | 4,770 | 197 | [link](cuda-rtx3080-linux.md) |
 | NVIDIA DGX Spark (GB10) | llama.cpp CUDA | 3,978 | 159 | [link](cuda-gb10-linux.md) |
 | Apple M4 Pro 48 GB | llama.cpp Metal | 487 | 117 | [link](metal-m4-pro-48gb-macos.md) |
+| NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 1,008 | 101.2 | [link](cuda-gtx1080ti-linux.md) |
 | AMD Strix Halo 128 GB | llama.cpp ROCm HIP | 1,325 | 96 | [link](rocm-hip-strix-halo-128gb-archlinux.md) |
 | AMD Strix Halo 128 GB | llama.cpp Vulkan | 831 | 64 | [link](vulkan-strix-halo-128gb-archlinux.md) |
 | NVIDIA RTX A2000 Laptop (4 GB) | llama.cpp CUDA | 1,387 | 63 | [link](cuda-rtxa2000-debian.md) |

--- a/community-benchmarks/bonsai/cuda-gtx1080ti-linux.md
+++ b/community-benchmarks/bonsai/cuda-gtx1080ti-linux.md
@@ -1,0 +1,102 @@
+# NVIDIA GeForce GTX 1080 Ti — CUDA
+
+## Summary
+
+GTX 1080 Ti 11 GB (GP102, Pascal sm_61, compute 6.1) + prebuilt CUDA binaries (release `prism-9596`, build `9fcaed763`) on Linux, driver 580.173.02 (CUDA 13.0). All four model sizes fit and were fully GPU-offloaded.
+
+| Model | pp512 (t/s) | tg128 (t/s) |
+|-------|------------:|------------:|
+| Bonsai-27B | 285 | 28.3 |
+| Bonsai-8B | 1,008 | 101.2 |
+| Bonsai-4B | 1,721 | 145.8 |
+| Bonsai-1.7B | 4,047 | 243.9 |
+
+The 1-bit 27B packs to just 3.53 GiB (~1.125 bpw), leaving ~7.3 GiB of the 11 GB frame buffer free for KV/context — a modern iPhone-class footprint running on a legacy Pascal GPU. For comparison, the ternary (Q2_0) family on the same hardware is in [../ternary-bonsai/cuda-gtx1080ti-linux.md](../ternary-bonsai/cuda-gtx1080ti-linux.md): the 1-bit 27B decodes ~38% faster than ternary (28.3 vs 20.5 t/s) at ~half the weight size, while prefill is ~tied (285 vs 278 t/s) — the expected quality/size/speed trade between the two families. Pascal (sm_61) is a legacy compute capability, so these numbers reflect the prebuilt binaries running on an older-architecture GPU.
+
+## llama-bench Results
+
+### Bonsai-27B
+
+```bash
+BENCH=bin/cuda/llama-bench
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/gguf/27B/Bonsai-27B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           pp512 |        284.73 ± 0.56 |
+| qwen35 27B Q1_0                |   3.53 GiB |    26.90 B | CUDA       |  99 |   1 |           tg128 |         28.26 ± 0.09 |
+
+build: 9fcaed763 (9596)
+
+### Bonsai-8B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/gguf/8B/Bonsai-8B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 8B Q1_0                  |   1.07 GiB |     8.19 B | CUDA       |  99 |   1 |           pp512 |       1007.80 ± 1.95 |
+| qwen3 8B Q1_0                  |   1.07 GiB |     8.19 B | CUDA       |  99 |   1 |           tg128 |        101.15 ± 0.13 |
+
+build: 9fcaed763 (9596)
+
+### Bonsai-4B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/gguf/4B/Bonsai-4B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 4B Q1_0                  |  540.09 MiB |     4.02 B | CUDA       |  99 |   1 |           pp512 |       1720.52 ± 6.71 |
+| qwen3 4B Q1_0                  |  540.09 MiB |     4.02 B | CUDA       |  99 |   1 |           tg128 |        145.78 ± 0.38 |
+
+build: 9fcaed763 (9596)
+
+### Bonsai-1.7B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/gguf/1.7B/Bonsai-1.7B-Q1_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 1.7B Q1_0                |  231.13 MiB |     1.72 B | CUDA       |  99 |   1 |           pp512 |      4047.44 ± 109.27 |
+| qwen3 1.7B Q1_0                |  231.13 MiB |     1.72 B | CUDA       |  99 |   1 |           tg128 |        243.88 ± 0.86 |
+
+build: 9fcaed763 (9596)
+
+## Configuration
+
+- Prebuilt CUDA binaries from the Bonsai demo (`bin/cuda/llama-bench`, release `prism-9596`, build `9fcaed763`), default llama-bench settings (f16 KV).
+- Stock clocks/power, all 99 layers offloaded to GPU (`-ngl 99`), flash attention on (`-fa 1`).
+
+## Notes
+
+- Driver 580.173.02, CUDA 13.0. Pascal is compute capability 6.1 (sm_61) — the oldest currently-supported CUDA target in these builds; useful as a legacy-architecture data point.
+- The 3.53 GiB Q1_0 weights leave ~7.3 GiB of the 11 GiB frame buffer free for KV cache. At FP16 KV (~64 KiB/token) that is room for well over 100K tokens of context on the GPU.
+- Vision projector and dspark drafter not loaded (llama-bench measures the bare autoregressive model).
+
+## Hardware
+
+NVIDIA GeForce GTX 1080 Ti 11 GB (GP102, compute capability 6.1), dual-socket Intel Xeon (2 × 10 cores / 40 threads), 125 GiB RAM, Linux.
+
+```text
+Architecture:                            x86_64
+CPU(s):                                  40
+Model name:                              Genuine Intel(R) CPU 0000 @ 2.20GHz
+Thread(s) per core:                      2
+Core(s) per socket:                      10
+Socket(s):                               2
+
+Mem:           125Gi       5.1Gi        68Gi        26Mi        53Gi       120Gi
+
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.173.02             Driver Version: 580.173.02     CUDA Version: 13.0     |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce GTX 1080 Ti     Off |   00000000:02:00.0 Off |                  N/A |
+|  0%   39C    P8             12W /  250W |       3MiB /  11264MiB |      0%      Default |
++-----------------------------------------------------------------------------------------+
+```

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -17,6 +17,7 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | Apple M5 Pro 64 GB | llama.cpp Metal | 130 | 26.5 | | [link](mlx-m5-pro-macos.md) |
 | Apple M4 Pro 64 GB | MLX 2-bit | 120 | 24.8 | | [link](mlx-m4-pro-64gb-macos.md) |
 | Apple M4 Pro 64 GB | llama.cpp Metal | 116 | 19.0 | slower on this HW | [link](metal-m4-pro-64gb-macos.md) |
+| NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 278 | 20.5 | | [link](cuda-gtx1080ti-linux.md) |
 | Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](metal-m3-pro-macos.md) |
 
 ### 8B and smaller
@@ -24,6 +25,7 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | Hardware | Backend | 8B PP512 (t/s) | 8B TG128 (t/s) | Details |
 |----------|---------|---------------:|---------------:|---------|
 | NVIDIA RTX 4070 Ti SUPER 16 GB | llama.cpp CUDA (Windows) | 6,675 | 215.7 | [link](cuda-rtx4070tisuper-windows.md) |
+| NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 985 | 68.8 | [link](cuda-gtx1080ti-linux.md) |
 | Apple M3 Pro 18 GB | llama.cpp Metal | 288 | 51.3 | [link](metal-m3-pro-macos.md) |
 
 ## Available Formats

--- a/community-benchmarks/ternary-bonsai/cuda-gtx1080ti-linux.md
+++ b/community-benchmarks/ternary-bonsai/cuda-gtx1080ti-linux.md
@@ -1,0 +1,102 @@
+# NVIDIA GeForce GTX 1080 Ti — CUDA
+
+## Summary
+
+GTX 1080 Ti 11 GB (GP102, Pascal sm_61, compute 6.1) + prebuilt CUDA binaries (release `prism-9596`, build `9fcaed763`) on Linux, driver 580.173.02 (CUDA 13.0). All four model sizes fit and were fully GPU-offloaded.
+
+| Model | pp512 (t/s) | tg128 (t/s) |
+|-------|------------:|------------:|
+| Ternary-Bonsai-27B | 278 | 20.5 |
+| Ternary-Bonsai-8B | 985 | 68.8 |
+| Ternary-Bonsai-4B | 1,679 | 97.4 |
+| Ternary-Bonsai-1.7B | 4,025 | 169.9 |
+
+The 6.66 GiB ternary 27B weights fit comfortably in the 11 GB frame buffer with ~4.4 GiB to spare for KV/context — notable because a conventional Q4_K_M of the same 27B base (15.4 GiB) would not fit this card at all. Pascal (sm_61) is a legacy compute capability, so these numbers reflect the prebuilt binaries running on an older-architecture GPU. The 1-bit Bonsai family on the same hardware is in [../bonsai/cuda-gtx1080ti-linux.md](../bonsai/cuda-gtx1080ti-linux.md).
+
+## llama-bench Results
+
+### Ternary-Bonsai-27B
+
+```bash
+BENCH=bin/cuda/llama-bench
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | CUDA       |  99 |   1 |           pp512 |        278.47 ± 0.69 |
+| qwen35 27B Q2_0                |   6.66 GiB |    26.90 B | CUDA       |  99 |   1 |           tg128 |         20.54 ± 0.09 |
+
+build: 9fcaed763 (9596)
+
+### Ternary-Bonsai-8B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/ternary-gguf/8B/Ternary-Bonsai-8B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 8B Q2_0                  |   2.03 GiB |     8.19 B | CUDA       |  99 |   1 |           pp512 |        985.44 ± 4.82 |
+| qwen3 8B Q2_0                  |   2.03 GiB |     8.19 B | CUDA       |  99 |   1 |           tg128 |         68.84 ± 0.06 |
+
+build: 9fcaed763 (9596)
+
+### Ternary-Bonsai-4B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/ternary-gguf/4B/Ternary-Bonsai-4B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 4B Q2_0                  | 1019.50 MiB |     4.02 B | CUDA       |  99 |   1 |           pp512 |       1679.21 ± 4.05 |
+| qwen3 4B Q2_0                  | 1019.50 MiB |     4.02 B | CUDA       |  99 |   1 |           tg128 |         97.39 ± 0.34 |
+
+build: 9fcaed763 (9596)
+
+### Ternary-Bonsai-1.7B
+
+```bash
+LD_LIBRARY_PATH=$PWD/bin/cuda $BENCH -m models/ternary-gguf/1.7B/Ternary-Bonsai-1.7B-Q2_0.gguf -ngl 99 -fa 1
+```
+
+| model                          |       size |     params | backend    | ngl |  fa |            test |                  t/s |
+| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | --------------: | -------------------: |
+| qwen3 1.7B Q2_0                |  436.16 MiB |     1.72 B | CUDA       |  99 |   1 |           pp512 |      4025.07 ± 27.06 |
+| qwen3 1.7B Q2_0                |  436.16 MiB |     1.72 B | CUDA       |  99 |   1 |           tg128 |        169.92 ± 0.14 |
+
+build: 9fcaed763 (9596)
+
+## Configuration
+
+- Prebuilt CUDA binaries from the Bonsai demo (`bin/cuda/llama-bench`, release `prism-9596`, build `9fcaed763`), default llama-bench settings (f16 KV).
+- Stock clocks/power, all 99 layers offloaded to GPU (`-ngl 99`), flash attention on (`-fa 1`).
+
+## Notes
+
+- Driver 580.173.02, CUDA 13.0. Pascal is compute capability 6.1 (sm_61) — the oldest currently-supported CUDA target in these builds; useful as a legacy-architecture data point.
+- The 6.66 GiB Q2_0 weights leave ~4.4 GiB of the 11 GiB frame buffer free for KV cache. At FP16 KV (~64 KiB/token) that is room for roughly ~70K tokens of context on the GPU before spilling to system RAM; `BONSAI_KV4=1` (q4 KV) would roughly triple that headroom.
+- Vision projector and dspark drafter not loaded (llama-bench measures the bare autoregressive model).
+
+## Hardware
+
+NVIDIA GeForce GTX 1080 Ti 11 GB (GP102, compute capability 6.1), dual-socket Intel Xeon (2 × 10 cores / 40 threads), 125 GiB RAM, Linux.
+
+```text
+Architecture:                            x86_64
+CPU(s):                                  40
+Model name:                              Genuine Intel(R) CPU 0000 @ 2.20GHz
+Thread(s) per core:                      2
+Core(s) per socket:                      10
+Socket(s):                               2
+
+Mem:           125Gi       5.1Gi        68Gi        26Mi        53Gi       120Gi
+
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.173.02             Driver Version: 580.173.02     CUDA Version: 13.0     |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce GTX 1080 Ti     Off |   00000000:02:00.0 Off |                  N/A |
+|  0%   39C    P8             12W /  250W |       3MiB /  11264MiB |      0%      Default |
++-----------------------------------------------------------------------------------------+
+```


### PR DESCRIPTION
Adds `llama-bench` results for an **NVIDIA GeForce GTX 1080 Ti 11 GB** (Pascal GP102, compute capability 6.1 — the oldest currently-supported CUDA target in these builds) running the prebuilt CUDA binaries (build `9fcaed763` / `9596`) on Linux, driver 580.173.02 (CUDA 13.0).

Both families, all four sizes, fully GPU-offloaded (`-ngl 99 -fa 1`):

| Family | Size | PP512 (t/s) | TG128 (t/s) |
|---|---|---|---|
| Ternary-Bonsai 27B | 6.66 GiB | 278.47 | 20.54 |
| Bonsai (1-bit) 27B | 3.53 GiB | 284.73 | 28.26 |
| Ternary-Bonsai 8B | 2.03 GiB | 985.44 | 68.84 |
| Bonsai (1-bit) 8B | 1.07 GiB | 1,007.80 | 101.15 |
| Ternary-Bonsai 4B | 1.02 GiB | 1,679.21 | 97.39 |
| Bonsai (1-bit) 4B | 540 MiB | 1,720.52 | 145.78 |
| Ternary-Bonsai 1.7B | 436 MiB | 4,025.07 | 169.92 |
| Bonsai (1-bit) 1.7B | 231 MiB | 4,047.44 | 243.88 |

Notable: the 6.66 GiB ternary 27B fits the 11 GB frame buffer with ~4.4 GiB to spare for KV (a 15 GiB Q4_K_M of the same base would not fit at all). The 1-bit 27B decodes ~38% faster than ternary (28.3 vs 20.5 t/s) at ~half the weight size, with prefill ~tied — the expected quality/size/speed trade-off between the families.

## Changes
- New: `community-benchmarks/ternary-bonsai/cuda-gtx1080ti-linux.md` (all four ternary sizes)
- New: `community-benchmarks/bonsai/cuda-gtx1080ti-linux.md` (all four 1-bit sizes)
- Updated index tables (rows inserted in TG128-descending order): `community-benchmarks/README.md`, `bonsai/README.md`, `ternary-bonsai/README.md`