### PR TITLE
scripts: speculative ctx should raise the tiered default, not override it

### DIFF
--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -107,9 +107,9 @@ if [ "$BONSAI_MODEL" = "27B" ]; then
             _spec_flags="--spec-type draft-dspark --spec-draft-n-max $_nmax -ngld 999 -np 1"
             # dspark re-prefills every request; give the model room to think
             # (it drafts 1.5-2k tokens; a small context truncates answers).
-            # An explicit non-zero BONSAI_CTX still wins; unset or 0 (auto) gets
-            # this dspark-friendly floor.
-            case "${BONSAI_CTX:-0}" in 0|"") _ctx=16384 ;; esac
+            # Raise the auto floor to 16384 if the tiered default is smaller;
+            # an explicit non-zero BONSAI_CTX wins as usual.
+            [ "$_ctx" -lt 16384 ] 2>/dev/null && _ctx=16384
             echo "  Speculative: $(basename "$MD") (draft-dspark, n-max $_nmax)"
         else
             warn "BONSAI_SPECULATIVE=1 but no *dspark-Q4_1*.gguf drafter in ${GGUF_MODEL_DIR}/; running without speculation."


### PR DESCRIPTION
## Problem

With `BONSAI_SPECULATIVE=1`, the speculative-decoding branch in `scripts/start_llama_server.sh` *overrode* the context size to a fixed `16384` whenever `BONSAI_CTX` was unset or `0`:

```sh
case "${BONSAI_CTX:-0}" in 0|"") _ctx=16384 ;; esac
```

This contradicts the `BONSAI_CTX=0` = "auto" semantics established in #127 / `common.sh:169`, where `0`/unset resolves to the RAM-tiered default. So a 48 GB+ machine (auto tier `131072`) would get silently capped to `16384` as soon as speculative decoding was turned on.

The floor exists for a real reason (dspark re-prefills every request and drafts 1.5-2k tokens, so a tiny context truncates answers), but it should be a **floor**, not a hard override.

## Fix

`_ctx` is already initialized to `CTX_SIZE_DEFAULT` (line 100), which honors `BONSAI_CTX` semantics from `common.sh` (explicit non-zero wins, `0`/unset = RAM tier). Replace the override with a raise:

```sh
[ "$_ctx" -lt 16384 ] 2>/dev/null && _ctx=16384
```

## Behavior (`BONSAI_SPECULATIVE=1`)

| Auto tier (RAM) | Before | After |
|---|---|---|
| 8192 (≤11 GB) | 16384 | 16384 (raised) |
| 16384 (≤23 GB) | 16384 | 16384 |
| 32768 (≤35 GB) | **16384** ❌ | **32768** |
| 65536 (≤71 GB) | **16384** ❌ | **65536** |
| 131072 (>71 GB, 27B) | **16384** ❌ | **131072** |

Explicit `BONSAI_CTX=N` (non-zero) is unchanged — it always wins. `2>/dev/null` guards the `-lt` comparison in case `_ctx` is ever non-numeric.

Verified `sh -n` passes.