### PR TITLE
docs: consolidate full environment-variable reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Every script in this repo is driven by environment variables — model selection
 
 The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs \"80;86\" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs \"80;86;89;90\"`) — see the "Building from Source" section below.
 
+**Platform coverage:** the model/setup vars (`BONSAI_FAMILY`, `BONSAI_MODEL`, `BONSAI_TOKEN`) and the llama.cpp server vars (`BONSAI_HOST`, `BONSAI_CTX`, `BONSAI_NGL`, `BONSAI_IMAGE_MAX_TOKENS`, `BONSAI_MMPROJ_CPU`, `BONSAI_SPECULATIVE`, `BONSAI_SPEC_NMAX`, `BONSAI_KV4`) work on **Linux, macOS, and Windows** (the `.ps1` launchers mirror the `.sh` ones). The **MLX** vars (`BONSAI_BACKEND=mlx`, `BONSAI_MLX_VLM`, `BONSAI_MLX_VISION`, `BONSAI_SKIP_MLX`) and the **Open WebUI** vars (`BONSAI_ALLOW_REMOTE`, `BONSAI_LOG`, `BONSAI_LLAMA_VERBOSE`, `BONSAI_MAX_TOOL_ITERS`, `BONSAI_CODE_INTERPRETER`, `BONSAI_JUPYTER_PORT`, `BONSAI_BRAVE_TOOLS`, `BRAVE_API_KEY`) are **macOS/Linux only** — MLX is Apple Silicon-only, and Open WebUI has no Windows launcher (`start_openwebui.sh` only; `setup.ps1` doesn't install it), so those vars have no effect on Windows.
+
 Combine them freely:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -146,45 +146,19 @@ This is the default family. Set `BONSAI_FAMILY=bonsai` to use the 1-bit Bonsai f
 
 Both variables are optional. **If you set neither, the default is `Ternary-Bonsai-27B`:** that's what plain `./setup.sh` downloads and runs.
 
-Every script in this repo is driven by environment variables — model selection and server behavior are all configured this way. The reference below covers the demo's **own** user-configurable variables (internal outputs the scripts set for themselves, like `BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, or `BONSAI_CODE_INTERPRETER_ON`, are not listed). They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and the `run_*` / `start_*` launchers (Linux, macOS, and Windows). The build scripts take CLI flags rather than env vars (see below), and the llama.cpp/MLX runtimes accept a few env vars of their own that are not listed here — for example, M5 Macs may need `GGML_METAL_TENSOR_DISABLE=1` (see the FAQ below).
+Every launcher is configured through environment variables. The most common ones:
 
-| Variable | Default | Valid values | Purpose |
-|----------|---------|--------------|---------|
-| **Model & setup** | | | |
-| `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all` | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
-| `BONSAI_MODEL` | `27B` | `27B`, `8B`, `4B`, `1.7B`, `all` | Model size. `all` expands to all four sizes (setup/download only). |
-| `BONSAI_TOKEN` | — | HF read-only token | Only needed for the 27B models while their repos are private (removed at launch). May also be stored in a gitignored `.bonsai_token` file. |
-| `BONSAI_SKIP_GGUF` | unset | `1` | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
-| `BONSAI_SKIP_MLX` | unset | `1` | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
-| `BONSAI_OPENWEBUI` | `1` | `0` | Skip installing Open WebUI during `setup.sh`. (`setup.sh` only installs it — the demo is launched separately with `./scripts/start_openwebui.sh`.) |
-| **llama.cpp server** | | | |
-| `BONSAI_HOST` | `127.0.0.1` | any bind address | Bind address. For `start_llama_server.sh` this is the llama-server's `--host`. For `start_openwebui.sh` it binds the **Open WebUI** UI instead (its managed llama-server stays on `127.0.0.1`), so a non-loopback value exposes the unauthenticated UI/code interpreter — that requires opt-in via `BONSAI_ALLOW_REMOTE=1` (trusted networks only). |
-| `BONSAI_CTX` | auto (RAM-tiered) | `0`, or ≤ `262144` | Context length. `0`/unset = automatic RAM-tiered size (never `-c 0`); an explicit number forces it (e.g. `262144` for full training context). |
-| `BONSAI_NGL` | auto-detect | any int; `0` = CPU-only | Override GPU layer offload. Auto-detect keys on installed tooling, so weak iGPUs can be better with `0`. |
-| `BONSAI_IMAGE_MAX_TOKENS` | `1024` on Metal/Vulkan/CPU; uncapped on CUDA/ROCm | number; `0` = uncapped | Cap on vision tokens per image (27B). `0` restores full detail (best for OCR / screenshots / small text) but is slower on large images. |
-| `BONSAI_MMPROJ_CPU` | unset | `1` | Keep the 27B vision projector in system RAM instead of VRAM (`--no-mmproj-offload`), freeing ~0.9 GiB for KV/context; slower image prefill. |
-| `BONSAI_SPECULATIVE` | `0` | `1` | Enable speculative decoding with the paired dspark drafter (~1.8–2x decode on code/reasoning; CUDA — not recommended on Apple Silicon yet). Opt-in, server-only. [SPECULATIVE.md](SPECULATIVE.md) |
-| `BONSAI_SPEC_NMAX` | `4` | int | dspark draft n-max override (PowerShell scripts only). |
-| `BONSAI_KV4` | `0` | `1` | 4-bit (Q4_0) KV cache, ~3.5x less KV memory for very long contexts; decode slightly slower than F16. Optional calibration bias via `./scripts/make_kv_bias.sh`. [KV-CACHE.md](KV-CACHE.md) |
-| **MLX server** | | | |
-| `BONSAI_BACKEND` | `llama` | `llama`, `mlx` | Which backend `start_openwebui.sh` serves (`mlx` is Apple Silicon-only). It does **not** change `run_llama.sh` / `run_llama.ps1` / `run_mlx.sh` — those pick their backend by which script you invoke. |
-| `BONSAI_MLX_VLM` | `1` | `0` | Use mlx-vlm for MLX image input (27B ternary; needs the `.venv-vlm` from setup.sh). |
-| `BONSAI_MLX_VISION` | `0` | `1` | Force MLX vision for a pre-existing MLX server whose implementation isn't known (set it explicitly if you started it with mlx-vlm). |
-| **Open WebUI** | | | |
-| `BONSAI_ALLOW_REMOTE` | `0` | `1` | Allow binding Open WebUI to a non-loopback `BONSAI_HOST`. Auth is disabled + a code interpreter may be enabled, so this is trusted-networks-only. |
-| `BONSAI_LOG` | `1` | `0` | Discard run logs to `/dev/null` instead of writing fresh timestamped logs under `.openwebui/logs/`. |
-| `BONSAI_LLAMA_VERBOSE` | `0` | `1` | Run llama-server with `-v` for full request-body debugging (very noisy; for diffing tool-call rounds). |
-| `BONSAI_MAX_TOOL_ITERS` | `30` | int; `-1` = unlimited | Cap on the native tool-call loop rounds in Open WebUI (default 30; `-1` unbounded). |
-| `BONSAI_CODE_INTERPRETER` | `1` | `0` | Disable the server-side Jupyter code interpreter (falls back to the browser Pyodide — plots still work, but no yfinance/network). |
-| `BONSAI_JUPYTER_PORT` | `8888` | port | Port for the Jupyter code interpreter kernel. |
-| `BONSAI_BRAVE_TOOLS` | `brave_web_search brave_news_search brave_summarizer` | space-separated tool names | Which Brave MCP tools to expose (~2.9k prompt tokens for the default three; the full set is ~29k). |
-| `BRAVE_API_KEY` | — | Brave Search API key | Enables the Brave web-search MCP server (or a gitignored `.brave_key` file; needs `npm i -g @brave/brave-search-mcp-server`). [TOOLS.md](TOOLS.md) |
+| Variable | Default | Values | Purpose |
+|----------|---------|--------|---------|
+| `BONSAI_MODEL` | `27B` | `27B`, `8B`, `4B`, `1.7B` | Model size. |
+| `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai` | Model family (`ternary` = Ternary-Bonsai, `bonsai` = 1-bit Bonsai). |
+| `BONSAI_NGL` | auto-detect | int; `0` = CPU-only | GPU layer offload. |
+| `BONSAI_CTX` | auto (RAM-tiered) | `0`, or ≤ `262144` | Context length (`0`/unset = automatic safe size). |
+| `BONSAI_HOST` | `127.0.0.1` | any bind address | Server bind address. A non-loopback value exposes the server — see the security note in the full reference. |
+| `BONSAI_SPECULATIVE` | `0` | `1` | Speculative decoding with the dspark drafter ([SPECULATIVE.md](SPECULATIVE.md)). |
+| `BONSAI_KV4` | `0` | `1` | 4-bit KV cache for long contexts ([KV-CACHE.md](KV-CACHE.md)). |
 
-`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size. Extra llama-server flags (e.g. `--reasoning-budget N`, `-ub 1024`) pass straight through as trailing arguments to the **standalone llama-server launchers** (`start_llama_server.sh` / `start_llama_server.ps1`); `start_openwebui.sh` forwards its trailing arguments to `open-webui serve` instead.
-
-The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs "80;86" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs "80;86;89;90"`) — see the "Building from Source" section below.
-
-**Platform coverage:** the model/setup vars (`BONSAI_FAMILY`, `BONSAI_MODEL`, `BONSAI_TOKEN`) and the llama.cpp server vars (`BONSAI_HOST`, `BONSAI_CTX`, `BONSAI_NGL`, `BONSAI_IMAGE_MAX_TOKENS`, `BONSAI_MMPROJ_CPU`, `BONSAI_SPECULATIVE`, `BONSAI_SPEC_NMAX`, `BONSAI_KV4`) work on **Linux, macOS, and Windows** (the `.ps1` launchers mirror the `.sh` ones). The **MLX** vars (`BONSAI_BACKEND=mlx`, `BONSAI_MLX_VLM`, `BONSAI_MLX_VISION`, `BONSAI_SKIP_MLX`) and the **Open WebUI** vars (`BONSAI_ALLOW_REMOTE`, `BONSAI_LOG`, `BONSAI_LLAMA_VERBOSE`, `BONSAI_MAX_TOOL_ITERS`, `BONSAI_CODE_INTERPRETER`, `BONSAI_JUPYTER_PORT`, `BONSAI_BRAVE_TOOLS`, `BRAVE_API_KEY`) are **macOS/Linux only** — MLX is Apple Silicon-only, and Open WebUI has no Windows launcher (`start_openwebui.sh` only; `setup.ps1` doesn't install it), so those vars have no effect on Windows.
+**Full reference** — all 24 variables (model/setup, server, MLX, Open WebUI, tools, and platform coverage): **[environment_variables.md](environment_variables.md)**.
 
 Combine them freely:
 

--- a/README.md
+++ b/README.md
@@ -144,17 +144,45 @@ This is the default family. Set `BONSAI_FAMILY=bonsai` to use the 1-bit Bonsai f
 
 ### Environment variables
 
-Both variables are optional. **If you set neither, the default is `Ternary-Bonsai-27B`:** that's what plain `./setup.sh` downloads and runs. They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every `run_*` / `start_*` script (Linux, macOS, and Windows).
+Both variables are optional. **If you set neither, the default is `Ternary-Bonsai-27B`:** that's what plain `./setup.sh` downloads and runs.
 
-| Variable        | Default   | Valid values                       | Purpose |
-|-----------------|-----------|------------------------------------|---------|
-| `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all`         | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
-| `BONSAI_MODEL`  | `27B`    | `27B`, `8B`, `4B`, `1.7B`, `all`   | Model size. `all` expands to all four sizes (setup/download only). |
-| `BONSAI_TOKEN`  | —        | HF read-only token                 | Only needed for the 27B models while their repos are private (removed at launch). |
-| `BONSAI_SKIP_GGUF` | unset  | `1`                                 | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
-| `BONSAI_SKIP_MLX`  | unset  | `1`                                 | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
+Every script in this repo is driven by environment variables — model selection, server behavior, the Open WebUI demo, and the build scripts all read them. The reference below covers every user-configurable variable (internal outputs the scripts set for themselves, like `BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, or `BONSAI_CODE_INTERPRETER_ON`, are not listed). They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every `run_*` / `start_*` script (Linux, macOS, and Windows).
 
-`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size.
+| Variable | Default | Valid values | Purpose |
+|----------|---------|--------------|---------|
+| **Model & setup** | | | |
+| `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all` | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
+| `BONSAI_MODEL` | `27B` | `27B`, `8B`, `4B`, `1.7B`, `all` | Model size. `all` expands to all four sizes (setup/download only). |
+| `BONSAI_TOKEN` | — | HF read-only token | Only needed for the 27B models while their repos are private (removed at launch). May also be stored in a gitignored `.bonsai_token` file. |
+| `BONSAI_SKIP_GGUF` | unset | `1` | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
+| `BONSAI_SKIP_MLX` | unset | `1` | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
+| `BONSAI_OPENWEBUI` | `1` | `0` | Skip installing/starting Open WebUI during `setup.sh` (e.g. text-only llamaserver setups). |
+| **llama.cpp server** | | | |
+| `BONSAI_HOST` | `127.0.0.1` | any bind address | Address the llama-server binds to (`--host`). Set `0.0.0.0` for LAN/remote access. |
+| `BONSAI_CTX` | auto (RAM-tiered) | `0`, or ≤ `262144` | Context length. `0`/unset = automatic RAM-tiered size (never `-c 0`); an explicit number forces it (e.g. `262144` for full training context). |
+| `BONSAI_NGL` | auto-detect | any int; `0` = CPU-only | Override GPU layer offload. Auto-detect keys on installed tooling, so weak iGPUs can be better with `0`. |
+| `BONSAI_IMAGE_MAX_TOKENS` | `1024` on Metal/Vulkan/CPU; uncapped on CUDA/ROCm | number; `0` = uncapped | Cap on vision tokens per image (27B). `0` restores full detail (best for OCR / screenshots / small text) but is slower on large images. |
+| `BONSAI_MMPROJ_CPU` | unset | `1` | Keep the 27B vision projector in system RAM instead of VRAM (`--no-mmproj-offload`), freeing ~0.9 GiB for KV/context; slower image prefill. |
+| `BONSAI_SPECULATIVE` | `0` | `1` | Enable speculative decoding with the paired dspark drafter (~1.8–2x decode on code/reasoning; CUDA — not recommended on Apple Silicon yet). Opt-in, server-only. [SPECULATIVE.md](SPECULATIVE.md) |
+| `BONSAI_SPEC_NMAX` | `4` | int | dspark draft n-max override (PowerShell scripts only). |
+| `BONSAI_KV4` | `0` | `1` | 4-bit (Q4_0) KV cache, ~3.5x less KV memory for very long contexts; decode slightly slower than F16. Optional calibration bias via `./scripts/make_kv_bias.sh`. [KV-CACHE.md](KV-CACHE.md) |
+| **MLX server** | | | |
+| `BONSAI_BACKEND` | `llama` | `llama`, `mlx` | Which single backend Open WebUI / run scripts use. `mlx` requires Apple Silicon (macOS arm64) and MLX weights. |
+| `BONSAI_MLX_VLM` | `1` | `0` | Use mlx-vlm for MLX image input (27B ternary; needs the `.venv-vlm` from setup.sh). |
+| `BONSAI_MLX_VISION` | `0` | `1` | Force MLX vision for a pre-existing MLX server whose implementation isn't known (set it explicitly if you started it with mlx-vlm). |
+| **Open WebUI** | | | |
+| `BONSAI_ALLOW_REMOTE` | `0` | `1` | Allow binding Open WebUI to a non-loopback `BONSAI_HOST`. Auth is disabled + a code interpreter may be enabled, so this is trusted-networks-only. |
+| `BONSAI_LOG` | `1` | `0` | Discard run logs to `/dev/null` instead of writing fresh timestamped logs under `.openwebui/logs/`. |
+| `BONSAI_LLAMA_VERBOSE` | `0` | `1` | Run llama-server with `-v` for full request-body debugging (very noisy; for diffing tool-call rounds). |
+| `BONSAI_MAX_TOOL_ITERS` | `30` | int; `-1` = unlimited | Cap on the native tool-call loop rounds in Open WebUI (default 30; `-1` unbounded). |
+| `BONSAI_CODE_INTERPRETER` | `1` | `0` | Disable the server-side Jupyter code interpreter (falls back to the browser Pyodide — plots still work, but no yfinance/network). |
+| `BONSAI_JUPYTER_PORT` | `8888` | port | Port for the Jupyter code interpreter kernel. |
+| `BONSAI_BRAVE_TOOLS` | `brave_web_search brave_news_search brave_summarizer` | space-separated tool names | Which Brave MCP tools to expose (~2.9k prompt tokens for the default three; the full set is ~29k). |
+| `BRAVE_API_KEY` | — | Brave Search API key | Enables the Brave web-search MCP server (or a gitignored `.brave_key` file; needs `npm i -g @brave/brave-search-mcp-server`). [TOOLS.md](TOOLS.md) |
+
+`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size. Extra llama-server flags (e.g. `--reasoning-budget N`, `-ub 1024`) also pass straight through to the start scripts as trailing arguments.
+
+The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs \"80;86\" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs \"80;86;89;90\"`) — see the "Building from Source" section below.
 
 Combine them freely:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This is the default family. Set `BONSAI_FAMILY=bonsai` to use the 1-bit Bonsai f
 
 Both variables are optional. **If you set neither, the default is `Ternary-Bonsai-27B`:** that's what plain `./setup.sh` downloads and runs.
 
-Every script in this repo is driven by environment variables — model selection, server behavior, the Open WebUI demo, and the build scripts all read them. The reference below covers every user-configurable variable (internal outputs the scripts set for themselves, like `BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, or `BONSAI_CODE_INTERPRETER_ON`, are not listed). They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and every `run_*` / `start_*` script (Linux, macOS, and Windows).
+Every script in this repo is driven by environment variables — model selection and server behavior are all configured this way. The reference below covers the demo's **own** user-configurable variables (internal outputs the scripts set for themselves, like `BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, or `BONSAI_CODE_INTERPRETER_ON`, are not listed). They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and the `run_*` / `start_*` launchers (Linux, macOS, and Windows). The build scripts take CLI flags rather than env vars (see below), and the llama.cpp/MLX runtimes accept a few env vars of their own that are not listed here — for example, M5 Macs may need `GGML_METAL_TENSOR_DISABLE=1` (see the FAQ below).
 
 | Variable | Default | Valid values | Purpose |
 |----------|---------|--------------|---------|
@@ -156,9 +156,9 @@ Every script in this repo is driven by environment variables — model selection
 | `BONSAI_TOKEN` | — | HF read-only token | Only needed for the 27B models while their repos are private (removed at launch). May also be stored in a gitignored `.bonsai_token` file. |
 | `BONSAI_SKIP_GGUF` | unset | `1` | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
 | `BONSAI_SKIP_MLX` | unset | `1` | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
-| `BONSAI_OPENWEBUI` | `1` | `0` | Skip installing/starting Open WebUI during `setup.sh` (e.g. text-only llamaserver setups). |
+| `BONSAI_OPENWEBUI` | `1` | `0` | Skip installing Open WebUI during `setup.sh`. (`setup.sh` only installs it — the demo is launched separately with `./scripts/start_openwebui.sh`.) |
 | **llama.cpp server** | | | |
-| `BONSAI_HOST` | `127.0.0.1` | any bind address | Address the llama-server binds to (`--host`). Set `0.0.0.0` for LAN/remote access. |
+| `BONSAI_HOST` | `127.0.0.1` | any bind address | Bind address. For `start_llama_server.sh` this is the llama-server's `--host`. For `start_openwebui.sh` it binds the **Open WebUI** UI instead (its managed llama-server stays on `127.0.0.1`), so a non-loopback value exposes the unauthenticated UI/code interpreter — that requires opt-in via `BONSAI_ALLOW_REMOTE=1` (trusted networks only). |
 | `BONSAI_CTX` | auto (RAM-tiered) | `0`, or ≤ `262144` | Context length. `0`/unset = automatic RAM-tiered size (never `-c 0`); an explicit number forces it (e.g. `262144` for full training context). |
 | `BONSAI_NGL` | auto-detect | any int; `0` = CPU-only | Override GPU layer offload. Auto-detect keys on installed tooling, so weak iGPUs can be better with `0`. |
 | `BONSAI_IMAGE_MAX_TOKENS` | `1024` on Metal/Vulkan/CPU; uncapped on CUDA/ROCm | number; `0` = uncapped | Cap on vision tokens per image (27B). `0` restores full detail (best for OCR / screenshots / small text) but is slower on large images. |
@@ -167,7 +167,7 @@ Every script in this repo is driven by environment variables — model selection
 | `BONSAI_SPEC_NMAX` | `4` | int | dspark draft n-max override (PowerShell scripts only). |
 | `BONSAI_KV4` | `0` | `1` | 4-bit (Q4_0) KV cache, ~3.5x less KV memory for very long contexts; decode slightly slower than F16. Optional calibration bias via `./scripts/make_kv_bias.sh`. [KV-CACHE.md](KV-CACHE.md) |
 | **MLX server** | | | |
-| `BONSAI_BACKEND` | `llama` | `llama`, `mlx` | Which single backend Open WebUI / run scripts use. `mlx` requires Apple Silicon (macOS arm64) and MLX weights. |
+| `BONSAI_BACKEND` | `llama` | `llama`, `mlx` | Which backend `start_openwebui.sh` serves (`mlx` is Apple Silicon-only). It does **not** change `run_llama.sh` / `run_llama.ps1` / `run_mlx.sh` — those pick their backend by which script you invoke. |
 | `BONSAI_MLX_VLM` | `1` | `0` | Use mlx-vlm for MLX image input (27B ternary; needs the `.venv-vlm` from setup.sh). |
 | `BONSAI_MLX_VISION` | `0` | `1` | Force MLX vision for a pre-existing MLX server whose implementation isn't known (set it explicitly if you started it with mlx-vlm). |
 | **Open WebUI** | | | |
@@ -180,9 +180,9 @@ Every script in this repo is driven by environment variables — model selection
 | `BONSAI_BRAVE_TOOLS` | `brave_web_search brave_news_search brave_summarizer` | space-separated tool names | Which Brave MCP tools to expose (~2.9k prompt tokens for the default three; the full set is ~29k). |
 | `BRAVE_API_KEY` | — | Brave Search API key | Enables the Brave web-search MCP server (or a gitignored `.brave_key` file; needs `npm i -g @brave/brave-search-mcp-server`). [TOOLS.md](TOOLS.md) |
 
-`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size. Extra llama-server flags (e.g. `--reasoning-budget N`, `-ub 1024`) also pass straight through to the start scripts as trailing arguments.
+`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size. Extra llama-server flags (e.g. `--reasoning-budget N`, `-ub 1024`) pass straight through as trailing arguments to the **standalone llama-server launchers** (`start_llama_server.sh` / `start_llama_server.ps1`); `start_openwebui.sh` forwards its trailing arguments to `open-webui serve` instead.
 
-The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs \"80;86\" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs \"80;86;89;90\"`) — see the "Building from Source" section below.
+The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs "80;86" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs "80;86;89;90"`) — see the "Building from Source" section below.
 
 **Platform coverage:** the model/setup vars (`BONSAI_FAMILY`, `BONSAI_MODEL`, `BONSAI_TOKEN`) and the llama.cpp server vars (`BONSAI_HOST`, `BONSAI_CTX`, `BONSAI_NGL`, `BONSAI_IMAGE_MAX_TOKENS`, `BONSAI_MMPROJ_CPU`, `BONSAI_SPECULATIVE`, `BONSAI_SPEC_NMAX`, `BONSAI_KV4`) work on **Linux, macOS, and Windows** (the `.ps1` launchers mirror the `.sh` ones). The **MLX** vars (`BONSAI_BACKEND=mlx`, `BONSAI_MLX_VLM`, `BONSAI_MLX_VISION`, `BONSAI_SKIP_MLX`) and the **Open WebUI** vars (`BONSAI_ALLOW_REMOTE`, `BONSAI_LOG`, `BONSAI_LLAMA_VERBOSE`, `BONSAI_MAX_TOOL_ITERS`, `BONSAI_CODE_INTERPRETER`, `BONSAI_JUPYTER_PORT`, `BONSAI_BRAVE_TOOLS`, `BRAVE_API_KEY`) are **macOS/Linux only** — MLX is Apple Silicon-only, and Open WebUI has no Windows launcher (`start_openwebui.sh` only; `setup.ps1` doesn't install it), so those vars have no effect on Windows.
 

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -1,0 +1,44 @@
+# Environment variables
+
+Complete reference for the demo's user-configurable environment variables. The [README](README.md#environment-variables) covers the common ones; everything is listed here.
+
+Every script in this repo is driven by environment variables — model selection and server behavior are all configured this way. The reference below covers the demo's **own** user-configurable variables (internal outputs the scripts set for themselves, like `BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, or `BONSAI_CODE_INTERPRETER_ON`, are not listed). They're read by `setup.sh`, `setup.ps1`, `download_models.sh`, and the `run_*` / `start_*` launchers (Linux, macOS, and Windows). The build scripts take CLI flags rather than env vars (see below), and the llama.cpp/MLX runtimes accept a few env vars of their own that are not listed here — for example, M5 Macs may need `GGML_METAL_TENSOR_DISABLE=1` (see the [README FAQ](README.md#appendix--faq)).
+
+| Variable | Default | Valid values | Purpose |
+|----------|---------|--------------|---------|
+| **Model & setup** | | | |
+| `BONSAI_FAMILY` | `ternary` | `ternary`, `bonsai`, `all` | Model family. `ternary` = Ternary-Bonsai; `bonsai` = 1-bit Bonsai. `all` expands to both families (setup/download only). |
+| `BONSAI_MODEL` | `27B` | `27B`, `8B`, `4B`, `1.7B`, `all` | Model size. `all` expands to all four sizes (setup/download only). |
+| `BONSAI_TOKEN` | — | HF read-only token | Only needed for the 27B models while their repos are private (removed at launch). May also be stored in a gitignored `.bonsai_token` file. |
+| `BONSAI_SKIP_GGUF` | unset | `1` | Skip the GGUF download entirely (macOS MLX-only setups, saves disk space). The llama.cpp scripts then point you at the MLX ones instead (see "Running the Model" below). |
+| `BONSAI_SKIP_MLX` | unset | `1` | Skip the MLX download (macOS only; MLX is skipped automatically on Intel Macs and non-macOS). |
+| `BONSAI_OPENWEBUI` | `1` | `0` | Skip installing Open WebUI during `setup.sh`. (`setup.sh` only installs it — the demo is launched separately with `./scripts/start_openwebui.sh`.) |
+| **llama.cpp server** | | | |
+| `BONSAI_HOST` | `127.0.0.1` | any bind address | Bind address. For `start_llama_server.sh` this is the llama-server's `--host`. For `start_openwebui.sh` it binds the **Open WebUI** UI instead (its managed llama-server stays on `127.0.0.1`), so a non-loopback value exposes the unauthenticated UI/code interpreter — that requires opt-in via `BONSAI_ALLOW_REMOTE=1` (trusted networks only). |
+| `BONSAI_CTX` | auto (RAM-tiered) | `0`, or ≤ `262144` | Context length. `0`/unset = automatic RAM-tiered size (never `-c 0`); an explicit number forces it (e.g. `262144` for full training context). |
+| `BONSAI_NGL` | auto-detect | any int; `0` = CPU-only | Override GPU layer offload. Auto-detect keys on installed tooling, so weak iGPUs can be better with `0`. |
+| `BONSAI_IMAGE_MAX_TOKENS` | `1024` on Metal/Vulkan/CPU; uncapped on CUDA/ROCm | number; `0` = uncapped | Cap on vision tokens per image (27B). `0` restores full detail (best for OCR / screenshots / small text) but is slower on large images. |
+| `BONSAI_MMPROJ_CPU` | unset | `1` | Keep the 27B vision projector in system RAM instead of VRAM (`--no-mmproj-offload`), freeing ~0.9 GiB for KV/context; slower image prefill. |
+| `BONSAI_SPECULATIVE` | `0` | `1` | Enable speculative decoding with the paired dspark drafter (~1.8–2x decode on code/reasoning; CUDA — not recommended on Apple Silicon yet). Opt-in, server-only. [SPECULATIVE.md](SPECULATIVE.md) |
+| `BONSAI_SPEC_NMAX` | `4` | int | dspark draft n-max override (PowerShell scripts only). |
+| `BONSAI_KV4` | `0` | `1` | 4-bit (Q4_0) KV cache, ~3.5x less KV memory for very long contexts; decode slightly slower than F16. Optional calibration bias via `./scripts/make_kv_bias.sh`. [KV-CACHE.md](KV-CACHE.md) |
+| **MLX server** | | | |
+| `BONSAI_BACKEND` | `llama` | `llama`, `mlx` | Which backend `start_openwebui.sh` serves (`mlx` is Apple Silicon-only). It does **not** change `run_llama.sh` / `run_llama.ps1` / `run_mlx.sh` — those pick their backend by which script you invoke. |
+| `BONSAI_MLX_VLM` | `1` | `0` | Use mlx-vlm for MLX image input (27B ternary; needs the `.venv-vlm` from setup.sh). |
+| `BONSAI_MLX_VISION` | `0` | `1` | Force MLX vision for a pre-existing MLX server whose implementation isn't known (set it explicitly if you started it with mlx-vlm). |
+| **Open WebUI** | | | |
+| `BONSAI_ALLOW_REMOTE` | `0` | `1` | Allow binding Open WebUI to a non-loopback `BONSAI_HOST`. Auth is disabled + a code interpreter may be enabled, so this is trusted-networks-only. |
+| `BONSAI_LOG` | `1` | `0` | Discard run logs to `/dev/null` instead of writing fresh timestamped logs under `.openwebui/logs/`. |
+| `BONSAI_LLAMA_VERBOSE` | `0` | `1` | Run llama-server with `-v` for full request-body debugging (very noisy; for diffing tool-call rounds). |
+| `BONSAI_MAX_TOOL_ITERS` | `30` | int; `-1` = unlimited | Cap on the native tool-call loop rounds in Open WebUI (default 30; `-1` unbounded). |
+| `BONSAI_CODE_INTERPRETER` | `1` | `0` | Disable the server-side Jupyter code interpreter (falls back to the browser Pyodide — plots still work, but no yfinance/network). |
+| `BONSAI_JUPYTER_PORT` | `8888` | port | Port for the Jupyter code interpreter kernel. |
+| `BONSAI_BRAVE_TOOLS` | `brave_web_search brave_news_search brave_summarizer` | space-separated tool names | Which Brave MCP tools to expose (~2.9k prompt tokens for the default three; the full set is ~29k). |
+| `BRAVE_API_KEY` | — | Brave Search API key | Enables the Brave web-search MCP server (or a gitignored `.brave_key` file; needs `npm i -g @brave/brave-search-mcp-server`). [TOOLS.md](TOOLS.md) |
+
+`all` is only valid for `setup.sh` / `setup.ps1` / `download_models.sh` — the run/server scripts need a concrete family/size. Extra llama-server flags (e.g. `--reasoning-budget N`, `-ub 1024`) pass straight through as trailing arguments to the **standalone llama-server launchers** (`start_llama_server.sh` / `start_llama_server.ps1`); `start_openwebui.sh` forwards its trailing arguments to `open-webui serve` instead.
+
+The build scripts take their options as **command-line flags, not environment variables** (e.g. `./scripts/build_cuda_linux.sh [repo_dir] --archs "80;86" --output cuda`, or `.\scripts\build_cuda_windows.ps1 -Archs "80;86;89;90"`) — see the README's "Building from Source" section.
+
+**Platform coverage:** the model/setup vars (`BONSAI_FAMILY`, `BONSAI_MODEL`, `BONSAI_TOKEN`) and the llama.cpp server vars (`BONSAI_HOST`, `BONSAI_CTX`, `BONSAI_NGL`, `BONSAI_IMAGE_MAX_TOKENS`, `BONSAI_MMPROJ_CPU`, `BONSAI_SPECULATIVE`, `BONSAI_SPEC_NMAX`, `BONSAI_KV4`) work on **Linux, macOS, and Windows** (the `.ps1` launchers mirror the `.sh` ones). The **MLX** vars (`BONSAI_BACKEND=mlx`, `BONSAI_MLX_VLM`, `BONSAI_MLX_VISION`, `BONSAI_SKIP_MLX`) and the **Open WebUI** vars (`BONSAI_ALLOW_REMOTE`, `BONSAI_LOG`, `BONSAI_LLAMA_VERBOSE`, `BONSAI_MAX_TOOL_ITERS`, `BONSAI_CODE_INTERPRETER`, `BONSAI_JUPYTER_PORT`, `BONSAI_BRAVE_TOOLS`, `BRAVE_API_KEY`) are **macOS/Linux only** — MLX is Apple Silicon-only, and Open WebUI has no Windows launcher (`start_openwebui.sh` only; `setup.ps1` doesn't install it), so those vars have no effect on Windows.
+


### PR DESCRIPTION
## Summary

Audited the codebase for **every user-configurable environment variable** and consolidated them into the existing "### Environment variables" section of `README.md` — previously it listed only 5 model-selection vars.

The table now covers **24 vars**, grouped by scope:

- **Model & setup** — `BONSAI_FAMILY`, `BONSAI_MODEL`, `BONSAI_TOKEN`, `BONSAI_SKIP_GGUF`, `BONSAI_SKIP_MLX`, `BONSAI_OPENWEBUI` (the last was previously undocumented)
- **llama.cpp server** — `BONSAI_HOST`, `BONSAI_CTX`, `BONSAI_NGL`, `BONSAI_IMAGE_MAX_TOKENS`, `BONSAI_MMPROJ_CPU`, `BONSAI_SPECULATIVE`, `BONSAI_SPEC_NMAX`, `BONSAI_KV4`
- **MLX server** — `BONSAI_BACKEND`, `BONSAI_MLX_VLM`, `BONSAI_MLX_VISION`
- **Open WebUI** — `BONSAI_ALLOW_REMOTE`, `BONSAI_LOG`, `BONSAI_LLAMA_VERBOSE`, `BONSAI_MAX_TOOL_ITERS`, `BONSAI_CODE_INTERPRETER`, `BONSAI_JUPYTER_PORT`, `BONSAI_BRAVE_TOOLS`, `BRAVE_API_KEY`

Defaults were verified against the actual script default expressions (`${VAR:-default}`). Rows link to the detail docs (SPECULATIVE.md, KV-CACHE.md, TOOLS.md). Internal-only script outputs (`BONSAI_DISPLAY`, `BONSAI_MCP_IDS`, `BONSAI_DEMO_DB`, `BONSAI_CODE_INTERPRETER_ON`) are intentionally excluded.

Also notes that the build scripts (`build_*.sh`) take their options as **CLI flags, not env vars**.

Docs-only change; no code or scripts were touched.
