### PR TITLE
fix: honor BONSAI_KV4 on Windows and BONSAI_SPEC_NMAX in the shell server

### DIFF
--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -144,6 +144,25 @@ if ($BonsaiModel -eq "27B") {
             Write-Host "[WARN] BONSAI_SPECULATIVE=1 but no *dspark-Q4_1*.gguf drafter in $ModelDir - running without speculation." -ForegroundColor Yellow
         }
     }
+    # 4-bit KV cache (opt-in, BONSAI_KV4=1): stores the KV cache in Q4_0 to cut
+    # KV memory for very long contexts on tight machines (decode is slightly
+    # slower than F16 KV). If a mean-centering bias built by
+    # scripts/make_kv_bias.sh is present it is applied automatically for
+    # better quality. Mirrors start_llama_server.sh.
+    $KvArgs = @()
+    if ($env:BONSAI_KV4 -eq "1") {
+        $KvArgs = @("--cache-type-k", "q4_0", "--cache-type-v", "q4_0")
+        $KvBias = Get-ChildItem -Path $ModelDir -Filter *kv-bias*.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($KvBias) {
+            # The bias is calibrated with K-rotation off; inference must match
+            # (the loader rejects a mismatch by design).
+            $env:LLAMA_ATTN_ROT_DISABLE = "1"
+            $KvArgs += @("--kv-mean-center", $KvBias.FullName)
+            Write-Host "  KV cache: q4_0 + mean-centering ($($KvBias.Name))" -ForegroundColor Green
+        } else {
+            Write-Host "  KV cache: q4_0 (no bias; run scripts/make_kv_bias.sh for better quality)" -ForegroundColor Green
+        }
+    }
     $ServerArgs = @(
         "-m", $Model.FullName,
         "--host", $HostAddress,
@@ -166,6 +185,7 @@ if ($BonsaiModel -eq "27B") {
         }
     }
     if ($SpecArgs.Count -gt 0) { $ServerArgs += $SpecArgs }
+    if ($KvArgs.Count -gt 0) { $ServerArgs += $KvArgs }
     # Image-token cap: big images cost minutes of prefill on slower hardware.
     # Capped at 1024 unless running the CUDA/HIP build; override with
     # BONSAI_IMAGE_MAX_TOKENS (a number, or 0 to disable the cap).

--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -155,7 +155,11 @@ if ($BonsaiModel -eq "27B") {
         $KvBias = Get-ChildItem -Path $ModelDir -Filter *kv-bias*.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($KvBias) {
             # The bias is calibrated with K-rotation off; inference must match
-            # (the loader rejects a mismatch by design).
+            # (the loader rejects a mismatch by design). Save any prior value so
+            # we can restore it in the finally block below (the shell launcher
+            # execs in a child process, but PowerShell shares the parent env and
+            # would otherwise leave this set for later launches).
+            $priorRotDisable = $env:LLAMA_ATTN_ROT_DISABLE
             $env:LLAMA_ATTN_ROT_DISABLE = "1"
             $KvArgs += @("--kv-mean-center", $KvBias.FullName)
             Write-Host "  KV cache: q4_0 + mean-centering ($($KvBias.Name))" -ForegroundColor Green
@@ -205,5 +209,15 @@ if ($BonsaiModel -eq "27B") {
 
 $EffCtx = if ($BonsaiModel -eq "27B") { $Ctx } else { $CtxDefault }
 Write-Host "  Context: -c $EffCtx (override with BONSAI_CTX, 0 = auto)"
-& $Bin @ServerArgs @args
-exit $LASTEXITCODE
+try {
+    & $Bin @ServerArgs @args
+    $code = $LASTEXITCODE
+} finally {
+    # Don't leak the KV4 bias flag into the parent PowerShell session.
+    if ($null -eq $priorRotDisable) {
+        Remove-Item Env:LLAMA_ATTN_ROT_DISABLE -ErrorAction SilentlyContinue
+    } else {
+        $env:LLAMA_ATTN_ROT_DISABLE = $priorRotDisable
+    }
+}
+exit $code

--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -26,6 +26,10 @@ try {
     exit 1
 } catch {}
 
+# Captured unconditionally: the finally block at the end restores it on every
+# launch, not just the ones where the KV4 bias block below sets it.
+$priorRotDisable = $env:LLAMA_ATTN_ROT_DISABLE
+
 if ($BonsaiFamily -eq "ternary") {
     $ModelDir = Join-Path $DemoDir "models\ternary-gguf\$BonsaiModel"
 
@@ -155,11 +159,10 @@ if ($BonsaiModel -eq "27B") {
         $KvBias = Get-ChildItem -Path $ModelDir -Filter *kv-bias*.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($KvBias) {
             # The bias is calibrated with K-rotation off; inference must match
-            # (the loader rejects a mismatch by design). Save any prior value so
-            # we can restore it in the finally block below (the shell launcher
-            # execs in a child process, but PowerShell shares the parent env and
-            # would otherwise leave this set for later launches).
-            $priorRotDisable = $env:LLAMA_ATTN_ROT_DISABLE
+            # (the loader rejects a mismatch by design). The finally block below
+            # restores the prior value (the shell launcher execs in a child
+            # process, but PowerShell shares the parent env and would otherwise
+            # leave this set for later launches).
             $env:LLAMA_ATTN_ROT_DISABLE = "1"
             $KvArgs += @("--kv-mean-center", $KvBias.FullName)
             Write-Host "  KV cache: q4_0 + mean-centering ($($KvBias.Name))" -ForegroundColor Green

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -103,7 +103,7 @@ if [ "$BONSAI_MODEL" = "27B" ]; then
             [ -f "$_md" ] && MD="$DEMO_DIR/$_md" && break
         done
         if [ -n "$MD" ]; then
-            _nmax=$(bonsai_dspark_block_size "$MD")
+            _nmax="${BONSAI_SPEC_NMAX:-$(bonsai_dspark_block_size "$MD")}"
             _spec_flags="--spec-type draft-dspark --spec-draft-n-max $_nmax -ngld 999 -np 1"
             # dspark re-prefills every request; give the model room to think
             # (it drafts 1.5-2k tokens; a small context truncates answers).


### PR DESCRIPTION
## Summary

Audit of environment-variable support across operating systems found the Windows (PowerShell) llama-server launcher was missing `BONSAI_KV4` entirely, and the shell launcher lacked the `BONSAI_SPEC_NMAX` override knob that PowerShell already had. This change closes both OS-parity gaps.

## Changes

- **`scripts/start_llama_server.ps1` — add `BONSAI_KV4` (Windows):** mirrors `start_llama_server.sh`. On `BONSAI_KV4=1`, passes `--cache-type-k q4_0 --cache-type-v q4_0`; auto-locates a `*-kv-bias*.gguf` in the model dir and, if present, adds `--kv-mean-center <path>` and exports `LLAMA_ATTN_ROT_DISABLE=1` (the bias is calibrated with K-rotation off). Emits the same status lines as the shell version. Previously this documented, user-configurable feature silently did nothing on Windows.
- **`scripts/start_llama_server.sh` — honor `BONSAI_SPEC_NMAX` (symmetry):** the net draft n-max now falls back to `BONSAI_SPEC_NMAX` if set, otherwise auto-detects the dspark block size from GGUF metadata — matching the existing PowerShell behavior.

## Validation

- `sh -n scripts/start_llama_server.sh` passes
- `start_llama_server.ps1` parses cleanly via the PowerShell AST parser

Only these two scripts changed; no other code touched.
