### PR TITLE
chore: add community benchmark for Ternary Bonsai 27B 2bit MLX with M4 24GB macbook pro

### DIFF
--- a/community-benchmarks/README.md
+++ b/community-benchmarks/README.md
@@ -23,6 +23,7 @@ Sorted by decode speed (TG128). The 27B models come in two families: Bonsai (1-b
 | Ternary | Apple M4 Pro 64 GB | MLX 2-bit | 120 | 24.8 | | [link](ternary-bonsai/mlx-m4-pro-64gb-macos.md) |
 | Ternary | Apple M4 Pro 64 GB | llama.cpp Metal | 116 | 19.0 | slower on this HW | [link](ternary-bonsai/metal-m4-pro-64gb-macos.md) |
 | Ternary | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 278 | 20.5 | | [link](ternary-bonsai/cuda-gtx1080ti-linux.md) |
+| Ternary | Apple M4 24 GB | MLX 2-bit | 65.2 | 12.7 | | [link](ternary-bonsai/mlx-m4-24gb-macos.md) |
 | Ternary | Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](ternary-bonsai/metal-m3-pro-macos.md) |
 
 ## 8B and smaller

--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -19,6 +19,7 @@ Benchmark results submitted by the community running [Ternary-Bonsai](https://hu
 | Apple M4 Pro 64 GB | MLX 2-bit | 120 | 24.8 | | [link](mlx-m4-pro-64gb-macos.md) |
 | Apple M4 Pro 64 GB | llama.cpp Metal | 116 | 19.0 | slower on this HW | [link](metal-m4-pro-64gb-macos.md) |
 | NVIDIA GeForce GTX 1080 Ti 11 GB | llama.cpp CUDA | 278 | 20.5 | | [link](cuda-gtx1080ti-linux.md) |
+| Apple M4 24 GB | MLX 2-bit | 65.2 | 12.7 | | [link](mlx-m4-24gb-macos.md) |
 | Apple M3 Pro 18 GB | llama.cpp Metal | 78.6 | 12.6 | | [link](metal-m3-pro-macos.md) |
 
 ### 8B and smaller

--- a/community-benchmarks/ternary-bonsai/mlx-m4-24gb-macos.md
+++ b/community-benchmarks/ternary-bonsai/mlx-m4-24gb-macos.md
@@ -1,73 +1,36 @@
-# Apple M4 (10-core GPU, 24 GB)  — MLX (2-bit)
+# Apple M4 24 GB — MLX (2-bit)
 
 ## Summary
 
-Apple M4 Macbook Pro (14 inch , November 2024) with 10-core GPU.
-
-  Chipset Model: Apple M4
-
-  Type: GPU
-
-  Bus: Built-In
-
-  Total Number of Cores: 10
-
-  Vendor: Apple (0x106b)
-
-  Metal Support: Metal 3
+Apple M4 MacBook Pro (14-inch, November 2024, 10-core GPU, 24 GB unified memory), macOS with MLX. Ternary-Bonsai-27B (MLX 2-bit): **~12.7 t/s generation, ~65 t/s prompt processing**, peak memory 8.8 GB — the 27B fits and runs comfortably on the 24 GB base M4.
 
 ## MLX Results (2-bit)
 
-Ternary-Bonsai ships as MLX 2-bit out of the box:
-
-- [Ternary-Bonsai-27B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit)
-- [Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
-- [Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
-- [Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)
-
-
-
-### Ternary-Bonsai-27B (the one we most want numbers for!)
+### Ternary-Bonsai-27B
 
 ```bash
 .venv/bin/python -m mlx_lm.benchmark --model models/Ternary-Bonsai-27B-mlx-2bit -p 512 -g 128
 ```
 
-Running warmup..
-
+```
 Timing with prompt_tokens=512, generation_tokens=128, batch_size=1.
-
 Trial 1:  prompt_tps=68.222, generation_tps=12.610, peak_memory=8.827, total_time=17.844
-
 Trial 2:  prompt_tps=67.151, generation_tps=12.793, peak_memory=8.828, total_time=17.852
-
 Trial 3:  prompt_tps=64.321, generation_tps=12.314, peak_memory=8.829, total_time=18.540
-
 Trial 4:  prompt_tps=61.916, generation_tps=12.803, peak_memory=8.829, total_time=18.456
-
 Trial 5:  prompt_tps=64.192, generation_tps=12.754, peak_memory=8.830, total_time=18.209
-
 Averages: prompt_tps=65.160, generation_tps=12.655, peak_memory=8.829
+```
+
+Model: [Ternary-Bonsai-27B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit)
 
 ## Configuration
 
-- mlx      0.31.2.dev20260817+10b5fe43
--  mlx-lm  0.31.2
-- One external 4K diplay connected
-
-
-
-## Notes
-
-
+- mlx 0.31.2.dev20260817+10b5fe43
+- mlx-lm 0.31.2
+- One external 4K display connected
 
 ## Hardware
-
-Not required, but helpful:
-
-```bash
-sysctl machdep.cpu.brand_string hw.memsize hw.ncpu && system_profiler SPDisplaysDataType 2>/dev/null | grep -E "Chipset Model|Number of Cores|Metal"
-```
 
 ```
 machdep.cpu.brand_string: Apple M4
@@ -77,4 +40,3 @@ hw.ncpu: 10
       Total Number of Cores: 10
       Metal Support: Metal 3
 ```
-

--- a/community-benchmarks/ternary-bonsai/mlx-m4-24gb-macos.md
+++ b/community-benchmarks/ternary-bonsai/mlx-m4-24gb-macos.md
@@ -1,0 +1,80 @@
+# Apple M4 (10-core GPU, 24 GB)  — MLX (2-bit)
+
+## Summary
+
+Apple M4 Macbook Pro (14 inch , November 2024) with 10-core GPU.
+
+  Chipset Model: Apple M4
+
+  Type: GPU
+
+  Bus: Built-In
+
+  Total Number of Cores: 10
+
+  Vendor: Apple (0x106b)
+
+  Metal Support: Metal 3
+
+## MLX Results (2-bit)
+
+Ternary-Bonsai ships as MLX 2-bit out of the box:
+
+- [Ternary-Bonsai-27B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-27B-mlx-2bit)
+- [Ternary-Bonsai-8B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-8B-mlx-2bit)
+- [Ternary-Bonsai-4B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-4B-mlx-2bit)
+- [Ternary-Bonsai-1.7B-mlx-2bit](https://huggingface.co/prism-ml/Ternary-Bonsai-1.7B-mlx-2bit)
+
+
+
+### Ternary-Bonsai-27B (the one we most want numbers for!)
+
+```bash
+.venv/bin/python -m mlx_lm.benchmark --model models/Ternary-Bonsai-27B-mlx-2bit -p 512 -g 128
+```
+
+Running warmup..
+
+Timing with prompt_tokens=512, generation_tokens=128, batch_size=1.
+
+Trial 1:  prompt_tps=68.222, generation_tps=12.610, peak_memory=8.827, total_time=17.844
+
+Trial 2:  prompt_tps=67.151, generation_tps=12.793, peak_memory=8.828, total_time=17.852
+
+Trial 3:  prompt_tps=64.321, generation_tps=12.314, peak_memory=8.829, total_time=18.540
+
+Trial 4:  prompt_tps=61.916, generation_tps=12.803, peak_memory=8.829, total_time=18.456
+
+Trial 5:  prompt_tps=64.192, generation_tps=12.754, peak_memory=8.830, total_time=18.209
+
+Averages: prompt_tps=65.160, generation_tps=12.655, peak_memory=8.829
+
+## Configuration
+
+- mlx      0.31.2.dev20260817+10b5fe43
+-  mlx-lm  0.31.2
+- One external 4K diplay connected
+
+
+
+## Notes
+
+
+
+## Hardware
+
+Not required, but helpful:
+
+```bash
+sysctl machdep.cpu.brand_string hw.memsize hw.ncpu && system_profiler SPDisplaysDataType 2>/dev/null | grep -E "Chipset Model|Number of Cores|Metal"
+```
+
+```
+machdep.cpu.brand_string: Apple M4
+hw.memsize: 25769803776
+hw.ncpu: 10
+      Chipset Model: Apple M4
+      Total Number of Cores: 10
+      Metal Support: Metal 3
+```
+


### PR DESCRIPTION
Added a community benchmark for Macbook Pro M4 24GB. 