### PR TITLE
Switch to prism-v7 builds and group-64 Q2_0 model files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ mlx/
 
 # Internal launch working notes — never commit
 TODOS.md
+llama.cpp

--- a/MODEL-FORMATS.md
+++ b/MODEL-FORMATS.md
@@ -1,0 +1,78 @@
+# Ternary model formats and the prism-v7 migration
+
+The 2-bit (ternary) Bonsai GGUFs exist in three formats. This page says which file to
+use, what changed in the prism-v7 migration, and why the current HuggingFace repos are
+named the way they are.
+
+## TL;DR
+
+- On prism-v7 (and newer) builds, the demo picks the right file automatically:
+  **PQ2_0** where the backend has optimized kernels, otherwise the official
+  **group-64 Q2_0**.
+- The old `*-Q2_0.gguf` files on the current repos are **deprecated**. They do not load
+  on prism-v7 builds (you get an error pointing you here). Use the `_g64` file or the
+  `PQ2_0` file instead.
+- For most people the official group-64 file is all you need. PQ2_0 buys about 6% less
+  memory (and, depending on backend, a matching speed edge) at the cost of running only
+  on backends with fork kernels.
+
+## The three formats
+
+| format | ggml type id | group size | who reads it |
+|---|---|---|---|
+| legacy `Q2_0` (deprecated) | 42 | 128 | pre-v7 fork releases only (`prism` = prism-v5 branch) |
+| official `Q2_0` | 42 | 64 | mainline llama.cpp AND prism-v7+ |
+| `PQ2_0` | 142 | 128 | prism-v7+ fork builds, on supported backends |
+
+The legacy format stored a group-128 layout under the same type id that mainline later
+standardized as group-64. prism-v7 follows mainline: type id 42 is read as group-64,
+and the fork's group-128 layout lives under its own name and id, PQ2_0 (142).
+
+## Exact file names on the current repos
+
+We decided NOT to rename already-published files (too many things link to them).
+Current repos therefore carry all three, and the official group-64 file has a
+transitional `_g64` suffix. Watch the 27B name, it differs:
+
+| size | deprecated (do not use on v7) | official group-64 | fork PQ2_0 |
+|---|---|---|---|
+| 1.7B | `Ternary-Bonsai-1.7B-Q2_0.gguf` | `Ternary-Bonsai-1.7B-Q2_0_g64.gguf` | `Ternary-Bonsai-1.7B-PQ2_0.gguf` |
+| 4B | `Ternary-Bonsai-4B-Q2_0.gguf` | `Ternary-Bonsai-4B-Q2_0_g64.gguf` | `Ternary-Bonsai-4B-PQ2_0.gguf` |
+| 8B | `Ternary-Bonsai-8B-Q2_0.gguf` | `Ternary-Bonsai-8B-Q2_0_g64.gguf` | `Ternary-Bonsai-8B-PQ2_0.gguf` |
+| 27B | `Ternary-Bonsai-27B-Q2_0.gguf` | `Ternary-Bonsai-27B-Q2_g64.gguf` | `Ternary-Bonsai-27B-PQ2_0.gguf` |
+
+Future model releases drop the transitional suffix: the official group-64 file will be
+named plain `*-Q2_0.gguf` and the fork file `*-PQ2_0.gguf`, with no legacy file at all.
+The demo scripts already handle both naming eras.
+
+## Which file should I use?
+
+- **Official group-64 Q2_0**: works everywhere (every fork backend and mainline
+  llama.cpp). If unsure, use this.
+- **PQ2_0**: about 6% smaller on disk and in memory. Runs on the backends listed
+  below; on others it has no kernels yet and would fall back to slow generic code.
+
+Backend support for PQ2_0 (the demo's selection registry, `pq2_0_ready_backend` in
+`scripts/common.sh`, mirrors this table):
+
+| backend | PQ2_0 kernels |
+|---|---|
+| Metal (macOS) | yes |
+| CUDA | yes |
+| ROCm / HIP | yes |
+| CPU (x86 VNNI, ARM NEON) | yes |
+| Vulkan | not yet (port planned) |
+| SYCL | not yet |
+
+## If you see the legacy-format error
+
+prism-v7 builds refuse the deprecated files with:
+
+```
+this file matches the legacy Prism Q2_0 layout (group size 128 stored as ggml type id 42),
+but this build reads Q2_0 as the official group-64 format
+```
+
+Download the `PQ2_0` or `_g64` file for your model from the same repo (table above),
+or if you must run the legacy file, use a release from the frozen `prism` (= prism-v5)
+branch.

--- a/MODEL-FORMATS.md
+++ b/MODEL-FORMATS.md
@@ -1,6 +1,6 @@
 # Ternary model formats and the prism-v7 migration
 
-The 2-bit (ternary) Bonsai GGUFs exist in three formats. This page says which file to
+The ternary Bonsai GGUFs exist in three formats. This page says which file to
 use, what changed in the prism-v7 migration, and why the current HuggingFace repos are
 named the way they are.
 

--- a/SPECULATIVE.md
+++ b/SPECULATIVE.md
@@ -1,8 +1,30 @@
 # Speculative decoding (experimental)
 
-> Note (prism-v7): the published 27B dspark drafter GGUFs predate the v7 format
-> convergence and do not load on v7 builds; re-exported drafters are in progress.
-> Speculative decoding is unavailable until they ship.
+> Note (prism-v7): the published 27B dspark drafter GGUFs for OLDER model releases
+> predate the v7 format convergence and do not load on v7 builds as-is. Convert
+> them once with the two commands below; newer model releases ship ready-to-use
+> drafters and need no conversion.
+
+## Converting the published drafter (older models)
+
+The converter ships with the fork (gguf-py, command `gguf-dspark-to-dflash`).
+Convert from the published bf16 drafter (NOT the Q4_1, which contains a legacy
+tensor), using the target model as the tokenizer donor, then quantize:
+
+```
+gguf-dspark-to-dflash --drop-shared-tensors \
+    models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-bf16.gguf \
+    models/ternary-gguf/27B/Ternary-Bonsai-27B-PQ2_0.gguf \
+    /tmp/drafter-conv.gguf
+llama-quantize /tmp/drafter-conv.gguf \
+    models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-dflash-Q4_0.gguf Q4_0
+```
+
+The output name must keep `dspark-dflash` in it, which is what
+`BONSAI_SPECULATIVE=1` looks for. `--drop-shared-tensors` omits the embedding
+and lm head (the runtime borrows the target's), shrinking the drafter to about
+0.6 GB with unchanged acceptance. Measured on the 27B: +29% decode on an M5 Max,
++73 to +93% on an L40S.
 
 ⚠️ **Highly experimental.** Try it for fun and only if you know what you are doing; expect it to change and be polished in later releases. The path is currently stable and fast on CUDA; Apple Silicon (Metal) support will be improved in a later release, so do not expect a speedup on Macs yet.
 

--- a/SPECULATIVE.md
+++ b/SPECULATIVE.md
@@ -1,5 +1,9 @@
 # Speculative decoding (experimental)
 
+> Note (prism-v7): the published 27B dspark drafter GGUFs predate the v7 format
+> convergence and do not load on v7 builds; re-exported drafters are in progress.
+> Speculative decoding is unavailable until they ship.
+
 ⚠️ **Highly experimental.** Try it for fun and only if you know what you are doing; expect it to change and be polished in later releases. The path is currently stable and fast on CUDA; Apple Silicon (Metal) support will be improved in a later release, so do not expect a speedup on Macs yet.
 
 **Fork-only.** The drafter runs on this demo's llama.cpp [binaries](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b9596-9fcaed7), not on mainline `ggml-org/llama.cpp`. Mainline now has its own DSpark ([#25173](https://github.com/ggml-org/llama.cpp/pull/25173)), but our drafter uses fork-specific GGUF packing (different tensor names, plus log-SNR conditioning mainline's graph doesn't have), so it fails to load with `gguf_init_from_reader: tensor 'dspark.fc.weight' has offset ..., expected ...` (tracked in [#26337](https://github.com/ggml-org/llama.cpp/issues/26337)).
@@ -29,7 +33,7 @@ If you run llama-server directly instead of through the start script, this is th
 
 ```bash
 bin/cuda/llama-server \
-  -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf \
+  -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_g64.gguf \
   -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-Q4_1.gguf \
   --spec-type draft-dspark --spec-draft-n-max 4 \
   -ngl 999 -ngld 999 -fa on -c 16384 -np 1 \
@@ -68,7 +72,7 @@ Each API response's `timings` object includes `draft_n` and `draft_n_accepted`. 
 
 ```bash
 bin/mac/llama-speculative-simple \
-  -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_0.gguf \
+  -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_g64.gguf \
   -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-Q4_1.gguf \
   --spec-type draft-dspark --spec-draft-n-max 4 \
   -ngl 999 -ngld 999 -c 8192 -n 400 --temp 0 -e \

--- a/SPECULATIVE.md
+++ b/SPECULATIVE.md
@@ -26,11 +26,9 @@ and lm head (the runtime borrows the target's), shrinking the drafter to about
 0.6 GB with unchanged acceptance. Measured on the 27B: +29% decode on an M5 Max,
 +73 to +93% on an L40S.
 
-⚠️ **Highly experimental.** Try it for fun and only if you know what you are doing; expect it to change and be polished in later releases. The path is currently stable and fast on CUDA; Apple Silicon (Metal) support will be improved in a later release, so do not expect a speedup on Macs yet.
+As of prism-v7, dspark rides on mainline llama.cpp's own DSpark implementation (upstream `draft-dspark`, [#25173](https://github.com/ggml-org/llama.cpp/pull/25173)) with a few fork-side patches on top (log-SNR conditioning, layout auto-detection from the model, the drafter converter; some of these will be proposed upstream). It is a supported path on both CUDA and Apple Silicon: at temperature 0 output is identical to normal decoding, and measured decode gains on the 27B are +29% on an M5 Max and +73 to +93% on an L40S, workload-dependent (code and reasoning draft best).
 
-**Fork-only.** The drafter runs on this demo's llama.cpp [binaries](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b9596-9fcaed7), not on mainline `ggml-org/llama.cpp`. Mainline now has its own DSpark ([#25173](https://github.com/ggml-org/llama.cpp/pull/25173)), but our drafter uses fork-specific GGUF packing (different tensor names, plus log-SNR conditioning mainline's graph doesn't have), so it fails to load with `gguf_init_from_reader: tensor 'dspark.fc.weight' has offset ..., expected ...` (tracked in [#26337](https://github.com/ggml-org/llama.cpp/issues/26337)).
-
-The 27B models ship with a paired **dspark drafter**: a small companion GGUF (`*dspark-Q4_1*.gguf`, downloaded automatically with the 27B weights) that drafts blocks of tokens for the target model to verify. On code and reasoning workloads this gives roughly **1.8-2x faster decode** on CUDA; acceptance is workload-dependent, so casual chat gains less. Output at temperature 0 is identical to normal decoding.
+The 27B models ship with a paired **dspark drafter**: a small companion GGUF (downloaded automatically with the 27B weights) that drafts blocks of tokens for the target model to verify. For older model releases the published drafter needs the one-time conversion above; newer releases ship ready-to-use drafters. On code and reasoning workloads this gives roughly **1.8-2x faster decode** on CUDA; acceptance is workload-dependent, so casual chat gains less. Output at temperature 0 is identical to normal decoding.
 
 Drafters are **target-specific**: each one only accelerates the exact model it was trained against. The demo downloads the matching drafter for whichever 27B family you use.
 

--- a/SPECULATIVE.md
+++ b/SPECULATIVE.md
@@ -28,7 +28,7 @@ and lm head (the runtime borrows the target's), shrinking the drafter to about
 
 As of prism-v7, dspark rides on mainline llama.cpp's own DSpark implementation (upstream `draft-dspark`, [#25173](https://github.com/ggml-org/llama.cpp/pull/25173)) with a few fork-side patches on top (log-SNR conditioning, layout auto-detection from the model, the drafter converter; some of these will be proposed upstream). It is a supported path on both CUDA and Apple Silicon: at temperature 0 output is identical to normal decoding, and measured decode gains on the 27B are +29% on an M5 Max and +73 to +93% on an L40S, workload-dependent (code and reasoning draft best).
 
-The 27B models ship with a paired **dspark drafter**: a small companion GGUF (downloaded automatically with the 27B weights) that drafts blocks of tokens for the target model to verify. For older model releases the published drafter needs the one-time conversion above; newer releases ship ready-to-use drafters. On code and reasoning workloads this gives roughly **1.8-2x faster decode** on CUDA; acceptance is workload-dependent, so casual chat gains less. Output at temperature 0 is identical to normal decoding.
+The 27B models ship with a paired **dspark drafter**: a small companion GGUF that drafts blocks of tokens for the target model to verify. The downloader fetches the bf16 drafter automatically with the 27B weights; for older model releases run the one-time conversion above to produce the loadable file, while newer releases ship ready-to-use drafters. On code and reasoning workloads this gives roughly **1.8-2x faster decode** on CUDA; acceptance is workload-dependent, so casual chat gains less. Output at temperature 0 is identical to normal decoding.
 
 Drafters are **target-specific**: each one only accelerates the exact model it was trained against. The demo downloads the matching drafter for whichever 27B family you use.
 
@@ -54,7 +54,7 @@ If you run llama-server directly instead of through the start script, this is th
 ```bash
 bin/cuda/llama-server \
   -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_g64.gguf \
-  -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-Q4_1.gguf \
+  -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-dflash-Q4_0.gguf \
   --spec-type draft-dspark --spec-draft-n-max 4 \
   -ngl 999 -ngld 999 -fa on -c 16384 -np 1 \
   --host 127.0.0.1 --port 8080
@@ -93,7 +93,7 @@ Each API response's `timings` object includes `draft_n` and `draft_n_accepted`. 
 ```bash
 bin/mac/llama-speculative-simple \
   -m models/ternary-gguf/27B/Ternary-Bonsai-27B-Q2_g64.gguf \
-  -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-Q4_1.gguf \
+  -md models/ternary-gguf/27B/Ternary-Bonsai-27B-dspark-dflash-Q4_0.gguf \
   --spec-type draft-dspark --spec-draft-n-max 4 \
   -ngl 999 -ngld 999 -c 8192 -n 400 --temp 0 -e \
   -p "<|im_start|>user\nImplement binary search in Python.<|im_end|>\n<|im_start|>assistant\n"

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -20,6 +20,7 @@ Every script in this repo is driven by environment variables — model selection
 | `BONSAI_IMAGE_MAX_TOKENS` | `1024` on Metal/Vulkan/CPU; uncapped on CUDA/ROCm | number; `0` = uncapped | Cap on vision tokens per image (27B). `0` restores full detail (best for OCR / screenshots / small text) but is slower on large images. |
 | `BONSAI_MMPROJ_CPU` | unset | `1` | Keep the 27B vision projector in system RAM instead of VRAM (`--no-mmproj-offload`), freeing ~0.9 GiB for KV/context; slower image prefill. |
 | `BONSAI_SPECULATIVE` | `0` | `1` | Enable speculative decoding with the paired dspark drafter (~1.8–2x decode on code/reasoning; CUDA — not recommended on Apple Silicon yet). Opt-in, server-only. [SPECULATIVE.md](SPECULATIVE.md) |
+| `PORT` | `8080` | Port for `start_llama_server.sh`. |
 | `BONSAI_SPEC_NMAX` | `4` | int | dspark draft n-max override (PowerShell scripts only). |
 | `BONSAI_KV4` | `0` | `1` | 4-bit (Q4_0) KV cache, ~3.5x less KV memory for very long contexts; decode slightly slower than F16. Optional calibration bias via `./scripts/make_kv_bias.sh`. [KV-CACHE.md](KV-CACHE.md) |
 | **MLX server** | | | |

--- a/llama.cpp
+++ b/llama.cpp
@@ -1,1 +1,0 @@
-/Users/pashak/workspace/llama-migration/llama.cpp-prism

--- a/llama.cpp
+++ b/llama.cpp
@@ -1,0 +1,1 @@
+/Users/pashak/workspace/llama-migration/llama.cpp-prism

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -117,6 +117,13 @@ select_model_gguf() {
         fi
     fi
     for _smg_p in $_smg_patterns; do
+        # plain *-Q2_0.gguf is only trusted when the downloader marked the dir as
+        # holding the OFFICIAL plain-named file (newer repos). Without the marker a
+        # plain Q2_0 file is a deprecated legacy leftover from a pre-v7 install,
+        # which v7 binaries refuse; skipping it here lets the download prompt fire.
+        if [ "$_smg_p" = "*-Q2_0.gguf" ] && [ ! -f "$_smg_dir/.official-q2_0" ]; then
+            continue
+        fi
         for _smg_m in $_smg_dir/$_smg_p; do
             [ -f "$_smg_m" ] || continue
             case "$_smg_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -30,7 +30,9 @@ case "$BONSAI_MODEL" in
             ternary)
                 GGUF_MODEL_DIR="models/ternary-gguf/${BONSAI_MODEL}"
                 MLX_MODEL_DIR="models/Ternary-Bonsai-${BONSAI_MODEL}-mlx-2bit"
-                GGUF_QUANT_PATTERN="*g64.gguf"
+                # ternary selection is backend-aware; see select_model_gguf below
+                # and MODEL-FORMATS.md for the PQ2_0 / group-64 Q2_0 story
+                GGUF_QUANT_PATTERN=""
                 BONSAI_DISPLAY="Ternary-Bonsai-${BONSAI_MODEL}"
                 ;;
             # Anything else, including "all": paths stay empty; assert_valid_model
@@ -71,16 +73,64 @@ _assert_concrete_model() {
     fi
 }
 
-# True if the concrete GGUF file for the current family/size is present
-# (matching GGUF_QUANT_PATTERN, excluding the mmproj/dspark/kv-bias extras --
-# same filter run_llama.sh / start_llama_server.sh use to pick MODEL).
-bonsai_gguf_present() {
-    for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
-        [ -f "$_m" ] || continue
-        case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
-        return 0
+# Backends with optimized PQ2_0 (fork group-128) kernels. Update this registry as
+# kernel ports land; anything not listed falls back to the official group-64 Q2_0
+# files, which every backend supports. See MODEL-FORMATS.md.
+pq2_0_ready_backend() {
+    case "$1" in
+        mac|cpu|cuda|rocm|hip|local) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Derive the backend name from a resolved llama-server binary path
+# (bin/<backend>/llama-server, or a local llama.cpp build -> "local").
+backend_from_bin() {
+    case "$1" in
+        */bin/mac/*)    echo mac ;;
+        */bin/cuda/*)   echo cuda ;;
+        */bin/rocm/*)   echo rocm ;;
+        */bin/hip/*)    echo hip ;;
+        */bin/vulkan/*) echo vulkan ;;
+        */bin/cpu/*)    echo cpu ;;
+        *)              echo local ;;
+    esac
+}
+
+# Print the model GGUF to use for the current family in dir $1, given backend $2
+# (optional; unknown/empty is treated as PQ2_0-ready).
+# Ternary preference order:
+#   1. *-PQ2_0.gguf        (fork group-128, when the backend has kernels for it)
+#   2. *g64.gguf           (official group-64 on pre-v7 repos: *_Q2_0_g64 / 27B *_Q2_g64)
+#   3. *-Q2_0.gguf         (official group-64 under its plain name on newer repos;
+#                           on pre-v7 repos this name is the DEPRECATED legacy file,
+#                           but those repos always carry a *g64.gguf so it is never
+#                           reached there unless only the legacy file is on disk)
+select_model_gguf() {
+    _smg_dir="$1"; _smg_backend="${2:-}"
+    if [ "$BONSAI_FAMILY" = "bonsai" ]; then
+        _smg_patterns="*-Q1_0.gguf"
+    else
+        _smg_patterns="*g64.gguf *-Q2_0.gguf"
+        if [ -z "$_smg_backend" ] || pq2_0_ready_backend "$_smg_backend"; then
+            _smg_patterns="*-PQ2_0.gguf $_smg_patterns"
+        fi
+    fi
+    for _smg_p in $_smg_patterns; do
+        for _smg_m in $_smg_dir/$_smg_p; do
+            [ -f "$_smg_m" ] || continue
+            case "$_smg_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
+            echo "$_smg_m"
+            return 0
+        done
     done
     return 1
+}
+
+# True if the concrete GGUF file for the current family/size is present
+# (excluding the mmproj/dspark/kv-bias extras -- same filter the launchers use).
+bonsai_gguf_present() {
+    select_model_gguf "$GGUF_MODEL_DIR" > /dev/null
 }
 
 # True if the MLX model for the current family/size is present.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -30,7 +30,7 @@ case "$BONSAI_MODEL" in
             ternary)
                 GGUF_MODEL_DIR="models/ternary-gguf/${BONSAI_MODEL}"
                 MLX_MODEL_DIR="models/Ternary-Bonsai-${BONSAI_MODEL}-mlx-2bit"
-                GGUF_QUANT_PATTERN="*-Q2_0.gguf"
+                GGUF_QUANT_PATTERN="*g64.gguf"
                 BONSAI_DISPLAY="Ternary-Bonsai-${BONSAI_MODEL}"
                 ;;
             # Anything else, including "all": paths stay empty; assert_valid_model

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -10,10 +10,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 
-# TODO(prism-v7 switch): set to the first prism-v7 release tag before merging.
 # v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
 # the legacy *-Q2_0.gguf files that pre-v7 releases used.
-RELEASE_TAG="prism-v7-TBD"
+RELEASE_TAG="prism-b10658-4725def"
 BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TAG"
 
 OS="$(uname -s)"

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -10,7 +10,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 
-RELEASE_TAG="prism-b9596-9fcaed7"
+# TODO(prism-v7 switch): set to the first prism-v7 release tag before merging.
+# v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
+# the legacy *-Q2_0.gguf files that pre-v7 releases used.
+RELEASE_TAG="prism-v7-TBD"
 BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TAG"
 
 OS="$(uname -s)"

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -103,7 +103,12 @@ download_one() {
             _gguf_dir="models/ternary-gguf/${_size}"
             _mlx_dir="models/Ternary-Bonsai-${_size}-mlx-2bit"
             _display="Ternary-Bonsai-${_size}"
-            _gguf_pattern="*g64.gguf"
+            # both ternary formats: PQ2_0 (fork group-128) and the official group-64
+            # Q2_0 (pre-v7 repos name it *_Q2_0_g64 / 27B *_Q2_g64). The launcher picks
+            # per backend at runtime; see select_model_gguf in common.sh and
+            # MODEL-FORMATS.md. Newer repos ship the official file as plain *-Q2_0.gguf;
+            # download_one falls back to that name when no *g64 file exists in the repo.
+            _gguf_pattern="*-PQ2_0.gguf,*g64.gguf"
             ;;
     esac
 
@@ -129,7 +134,14 @@ download_one() {
         info "Skipping GGUF ${_display} (BONSAI_SKIP_GGUF=1)."
     else
         _gguf_present=false
-        if [ -d "$_gguf_dir" ] && ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
+        _gguf_check_pattern="$(printf '%s' "$_gguf_pattern" | tr ',' ' ')"
+        _gguf_any_present() {
+            for _p in $_gguf_check_pattern; do
+                ls "$_gguf_dir"/$_p >/dev/null 2>&1 && return 0
+            done
+            return 1
+        }
+        if [ -d "$_gguf_dir" ] && _gguf_any_present; then
             if { [ -z "$_mmproj_pattern" ] || ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; } \
                 && { [ -z "$_drafter_pattern" ] || ls "$_gguf_dir"/$_drafter_pattern >/dev/null 2>&1; }; then
                 _gguf_present=true
@@ -144,9 +156,14 @@ download_one() {
                 err "Failed to download GGUF ${_display} from ${_gguf_repo}."
                 exit 1
             fi
-            if ! ls "$_gguf_dir"/$_gguf_pattern >/dev/null 2>&1; then
-                err "Download reported success but no file matching ${_gguf_pattern} was written to ${_gguf_dir}/."
-                exit 1
+            if ! _gguf_any_present; then
+                # newer repos ship the official group-64 file as plain *-Q2_0.gguf
+                # and carry no *g64 name; fall back to that exact pattern.
+                step "No PQ2_0/g64 file in ${_gguf_repo}; falling back to *-Q2_0.gguf (official group-64 on current repos) ..."
+                if ! hf_download "$_gguf_repo" "$_gguf_dir" "*-Q2_0.gguf" || ! ls "$_gguf_dir"/*-Q2_0.gguf >/dev/null 2>&1; then
+                    err "Download reported success but no usable model file was written to ${_gguf_dir}/."
+                    exit 1
+                fi
             fi
             if [ -n "$_mmproj_pattern" ] && ! ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; then
                 warn "No ${_mmproj_pattern} file in ${_gguf_repo} — image input will be disabled for ${_display}."

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -103,12 +103,22 @@ download_one() {
             _gguf_dir="models/ternary-gguf/${_size}"
             _mlx_dir="models/Ternary-Bonsai-${_size}-mlx-2bit"
             _display="Ternary-Bonsai-${_size}"
-            # both ternary formats: PQ2_0 (fork group-128) and the official group-64
-            # Q2_0 (pre-v7 repos name it *_Q2_0_g64 / 27B *_Q2_g64). The launcher picks
-            # per backend at runtime; see select_model_gguf in common.sh and
-            # MODEL-FORMATS.md. Newer repos ship the official file as plain *-Q2_0.gguf;
-            # download_one falls back to that name when no *g64 file exists in the repo.
-            _gguf_pattern="*-PQ2_0.gguf,*g64.gguf"
+            # ternary: download only the format the installed backend will use
+            # (PQ2_0 where it has kernels, official group-64 otherwise; both when no
+            # binary is installed yet). See select_model_gguf in common.sh and
+            # MODEL-FORMATS.md. Newer repos ship the official file as plain
+            # *-Q2_0.gguf; download_one falls back to that name when no *g64 exists.
+            _dl_backend=""
+            for _bd in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu; do
+                [ -d "$_bd" ] && _dl_backend="${_bd#bin/}" && break
+            done
+            if [ -z "$_dl_backend" ]; then
+                _gguf_pattern="*-PQ2_0.gguf,*g64.gguf"
+            elif pq2_0_ready_backend "$_dl_backend"; then
+                _gguf_pattern="*-PQ2_0.gguf"
+            else
+                _gguf_pattern="*g64.gguf"
+            fi
             ;;
     esac
 
@@ -121,7 +131,9 @@ download_one() {
     _drafter_pattern=""
     if [ "$_size" = "27B" ]; then
         _mmproj_pattern="*mmproj*.gguf"
-        _drafter_pattern="*dspark-Q4_1*.gguf"
+        # the bf16 drafter is the input for the one-time gguf-dspark-to-dflash
+        # conversion (see SPECULATIVE.md); the legacy Q4_1 sidecar cannot load on v7
+        _drafter_pattern="*dspark-bf16*.gguf"
         _dl_patterns="$_gguf_pattern,$_mmproj_pattern,$_drafter_pattern"
     fi
 
@@ -139,6 +151,8 @@ download_one() {
             for _p in $_gguf_check_pattern; do
                 ls "$_gguf_dir"/$_p >/dev/null 2>&1 && return 0
             done
+            # a previous run that fell back to the plain official name marked the dir
+            [ -f "$_gguf_dir/.official-q2_0" ] && ls "$_gguf_dir"/*-Q2_0.gguf >/dev/null 2>&1 && return 0
             return 1
         }
         if [ -d "$_gguf_dir" ] && _gguf_any_present; then
@@ -164,6 +178,9 @@ download_one() {
                     err "Download reported success but no usable model file was written to ${_gguf_dir}/."
                     exit 1
                 fi
+                # mark the dir: its plain-named Q2_0 is the OFFICIAL group-64 file, so
+                # the selector and the presence fast-path may trust that name here
+                touch "$_gguf_dir/.official-q2_0"
             fi
             if [ -n "$_mmproj_pattern" ] && ! ls "$_gguf_dir"/$_mmproj_pattern >/dev/null 2>&1; then
                 warn "No ${_mmproj_pattern} file in ${_gguf_repo} — image input will be disabled for ${_display}."

--- a/scripts/download_models.sh
+++ b/scripts/download_models.sh
@@ -103,7 +103,7 @@ download_one() {
             _gguf_dir="models/ternary-gguf/${_size}"
             _mlx_dir="models/Ternary-Bonsai-${_size}-mlx-2bit"
             _display="Ternary-Bonsai-${_size}"
-            _gguf_pattern="*-Q2_0.gguf"
+            _gguf_pattern="*g64.gguf"
             ;;
     esac
 

--- a/scripts/make_kv_bias.sh
+++ b/scripts/make_kv_bias.sh
@@ -20,8 +20,13 @@ DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 assert_gguf_downloaded
 
-# ── Find the target model: select exactly the demo quant for the family ──
-MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
+# ── Find the target model: backend-aware, so the bias matches the file
+#    start_llama_server.sh will actually load ──
+_kb_backend=""
+for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu; do
+    [ -f "$_d/llama-server" ] && _kb_backend="$(backend_from_bin "$_d/llama-server")" && break
+done
+MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" "$_kb_backend" || true)"
 [ -n "$MODEL" ] && MODEL="$DEMO_DIR/$MODEL"
 if [ -z "$MODEL" ]; then
     err "No model file found in ${GGUF_MODEL_DIR}/."

--- a/scripts/make_kv_bias.sh
+++ b/scripts/make_kv_bias.sh
@@ -21,14 +21,10 @@ cd "$DEMO_DIR"
 assert_gguf_downloaded
 
 # ── Find the target model: select exactly the demo quant for the family ──
-MODEL=""
-for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
-    [ -f "$_m" ] || continue
-    case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
-    MODEL="$DEMO_DIR/$_m" && break
-done
+MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
+[ -n "$MODEL" ] && MODEL="$DEMO_DIR/$MODEL"
 if [ -z "$MODEL" ]; then
-    err "No ${GGUF_QUANT_PATTERN} model found in ${GGUF_MODEL_DIR}/."
+    err "No model file found in ${GGUF_MODEL_DIR}/."
     exit 1
 fi
 

--- a/scripts/run_llama.ps1
+++ b/scripts/run_llama.ps1
@@ -27,10 +27,22 @@ if ($BonsaiFamily -eq "ternary") {
 
 # Select exactly the demo quant for the family (a leftover F16 or g64 file
 # must never be picked up).
-$QuantPattern = if ($BonsaiFamily -eq "ternary") { "*-Q2_0.gguf" } else { "*-Q1_0.gguf" }
-$Model = Get-ChildItem -Path $ModelDir -Filter $QuantPattern -File -ErrorAction SilentlyContinue |
-    Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
-    Select-Object -First 1
+$Model = $null
+if ($BonsaiFamily -eq "ternary") {
+    # PQ2_0 first (fork group-128; CPU/CUDA/HIP builds), then official group-64
+    # (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos). Vulkan builds have no
+    # PQ2_0 kernels yet: set BONSAI_FORCE_G64=1 to skip PQ2_0. See MODEL-FORMATS.md.
+    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1") { @("*g64.gguf", "*-Q2_0.gguf") }
+                   else { @("*-PQ2_0.gguf", "*g64.gguf", "*-Q2_0.gguf") }
+} else {
+    $tryPatterns = @("*-Q1_0.gguf")
+}
+foreach ($qp in $tryPatterns) {
+    $Model = Get-ChildItem -Path $ModelDir -Filter $qp -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
+        Select-Object -First 1
+    if ($Model) { break }
+}
 if (-not $Model) {
     Write-Host "[ERR] GGUF model not found for $FamilyDisplay-$BonsaiModel in $ModelDir" -ForegroundColor Red
     Write-Host "      Run .\setup.ps1 first." -ForegroundColor Yellow

--- a/scripts/run_llama.ps1
+++ b/scripts/run_llama.ps1
@@ -27,17 +27,33 @@ if ($BonsaiFamily -eq "ternary") {
 
 # Select exactly the demo quant for the family (a leftover F16 or g64 file
 # must never be picked up).
+$BinCandidates = @(
+    "bin\cuda\llama-cli.exe",
+    "bin\hip\llama-cli.exe",
+    "bin\vulkan\llama-cli.exe",
+    "bin\cpu\llama-cli.exe",
+    "llama.cpp\build\bin\Release\llama-cli.exe",
+    "llama.cpp\build\bin\llama-cli.exe"
+)
 $Model = $null
+$BinRel = $null
+foreach ($cand in $BinCandidates) {
+    if (Test-Path (Join-Path $DemoDir $cand)) { $BinRel = $cand; break }
+}
+$Pq2Ready = $BinRel -notlike "bin\vulkan\*"
 if ($BonsaiFamily -eq "ternary") {
-    # PQ2_0 first (fork group-128; CPU/CUDA/HIP builds), then official group-64
-    # (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos). Vulkan builds have no
-    # PQ2_0 kernels yet: set BONSAI_FORCE_G64=1 to skip PQ2_0. See MODEL-FORMATS.md.
-    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1") { @("*g64.gguf", "*-Q2_0.gguf") }
+    # PQ2_0 where the backend has kernels (see MODEL-FORMATS.md); official group-64
+    # otherwise (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos).
+    # BONSAI_FORCE_G64=1 skips PQ2_0 regardless of backend.
+    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1" -or -not $Pq2Ready) { @("*g64.gguf", "*-Q2_0.gguf") }
                    else { @("*-PQ2_0.gguf", "*g64.gguf", "*-Q2_0.gguf") }
 } else {
     $tryPatterns = @("*-Q1_0.gguf")
 }
 foreach ($qp in $tryPatterns) {
+    # plain *-Q2_0.gguf is only trusted with the downloader's .official-q2_0 marker
+    # (newer repos); otherwise it is a deprecated legacy leftover v7 refuses to load
+    if ($qp -eq "*-Q2_0.gguf" -and -not (Test-Path (Join-Path $ModelDir ".official-q2_0"))) { continue }
     $Model = Get-ChildItem -Path $ModelDir -Filter $qp -File -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
         Select-Object -First 1
@@ -49,15 +65,6 @@ if (-not $Model) {
     exit 1
 }
 
-$BinCandidates = @(
-    "bin\cuda\llama-cli.exe",
-    "bin\hip\llama-cli.exe",
-    "bin\vulkan\llama-cli.exe",
-    "bin\cpu\llama-cli.exe",
-    "llama.cpp\build\bin\Release\llama-cli.exe",
-    "llama.cpp\build\bin\llama-cli.exe"
-)
-$BinRel = $BinCandidates | Where-Object { Test-Path (Join-Path $DemoDir $_) } | Select-Object -First 1
 if (-not $BinRel) {
     Write-Host "[ERR] llama-cli.exe not found. Run .\setup.ps1 first." -ForegroundColor Red
     exit 1

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -10,21 +10,22 @@ DEMO_DIR="$(resolve_demo_dir)"
 cd "$DEMO_DIR"
 assert_gguf_downloaded run_mlx.sh
 
-# ── Find model: select exactly the demo quant for the family ──
-MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
-if [ -z "$MODEL" ]; then
-    err "No model file found in ${GGUF_MODEL_DIR}/."
-    echo "  Re-run ./scripts/download_models.sh to fetch the model weights."
-    exit 1
-fi
-
-# ── Find binary (search all known locations) ──
+# ── Find binary first (its backend decides the ternary quant; see common.sh) ──
 BIN=""
 for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
     [ -f "$DEMO_DIR/$_d/llama-cli" ] && BIN="$DEMO_DIR/$_d/llama-cli" && break
 done
 if [ -z "$BIN" ]; then
     err "llama-cli not found. Run ./setup.sh or ./scripts/download_binaries.sh first."
+    exit 1
+fi
+BACKEND="$(backend_from_bin "$BIN")"
+
+# ── Find model: backend-aware selection ──
+MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" "$BACKEND" || true)"
+if [ -z "$MODEL" ]; then
+    err "No model file found in ${GGUF_MODEL_DIR}/."
+    echo "  Re-run ./scripts/download_models.sh to fetch the model weights."
     exit 1
 fi
 

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -11,14 +11,9 @@ cd "$DEMO_DIR"
 assert_gguf_downloaded run_mlx.sh
 
 # ── Find model: select exactly the demo quant for the family ──
-MODEL=""
-for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
-    [ -f "$_m" ] || continue
-    case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
-    MODEL="$_m" && break
-done
+MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
 if [ -z "$MODEL" ]; then
-    err "No ${GGUF_QUANT_PATTERN} model found in ${GGUF_MODEL_DIR}/."
+    err "No model file found in ${GGUF_MODEL_DIR}/."
     echo "  Re-run ./scripts/download_models.sh to fetch the model weights."
     exit 1
 fi

--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -42,17 +42,33 @@ if ($BonsaiFamily -eq "ternary") {
 $Display = "$FamilyDisplay-$BonsaiModel"
 # Select exactly the demo quant for the family (a leftover F16 or g64 file
 # must never be picked up).
+$BinCandidates = @(
+    "bin\cuda\llama-server.exe",
+    "bin\hip\llama-server.exe",
+    "bin\vulkan\llama-server.exe",
+    "bin\cpu\llama-server.exe",
+    "llama.cpp\build\bin\Release\llama-server.exe",
+    "llama.cpp\build\bin\llama-server.exe"
+)
 $Model = $null
+$BinRel = $null
+foreach ($cand in $BinCandidates) {
+    if (Test-Path (Join-Path $DemoDir $cand)) { $BinRel = $cand; break }
+}
+$Pq2Ready = $BinRel -notlike "bin\vulkan\*"
 if ($BonsaiFamily -eq "ternary") {
-    # PQ2_0 first (fork group-128; CPU/CUDA/HIP builds), then official group-64
-    # (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos). Vulkan builds have no
-    # PQ2_0 kernels yet: set BONSAI_FORCE_G64=1 to skip PQ2_0. See MODEL-FORMATS.md.
-    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1") { @("*g64.gguf", "*-Q2_0.gguf") }
+    # PQ2_0 where the backend has kernels (see MODEL-FORMATS.md); official group-64
+    # otherwise (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos).
+    # BONSAI_FORCE_G64=1 skips PQ2_0 regardless of backend.
+    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1" -or -not $Pq2Ready) { @("*g64.gguf", "*-Q2_0.gguf") }
                    else { @("*-PQ2_0.gguf", "*g64.gguf", "*-Q2_0.gguf") }
 } else {
     $tryPatterns = @("*-Q1_0.gguf")
 }
 foreach ($qp in $tryPatterns) {
+    # plain *-Q2_0.gguf is only trusted with the downloader's .official-q2_0 marker
+    # (newer repos); otherwise it is a deprecated legacy leftover v7 refuses to load
+    if ($qp -eq "*-Q2_0.gguf" -and -not (Test-Path (Join-Path $ModelDir ".official-q2_0"))) { continue }
     $Model = Get-ChildItem -Path $ModelDir -Filter $qp -File -ErrorAction SilentlyContinue |
         Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
         Select-Object -First 1
@@ -71,15 +87,6 @@ if ($BonsaiModel -eq "27B" -and -not $Mmproj) {
     Write-Host "       Re-run setup.ps1 to fetch it." -ForegroundColor Yellow
 }
 
-$BinCandidates = @(
-    "bin\cuda\llama-server.exe",
-    "bin\hip\llama-server.exe",
-    "bin\vulkan\llama-server.exe",
-    "bin\cpu\llama-server.exe",
-    "llama.cpp\build\bin\Release\llama-server.exe",
-    "llama.cpp\build\bin\llama-server.exe"
-)
-$BinRel = $BinCandidates | Where-Object { Test-Path (Join-Path $DemoDir $_) } | Select-Object -First 1
 if (-not $BinRel) {
     Write-Host "[ERR] llama-server.exe not found. Run .\setup.ps1 first." -ForegroundColor Red
     exit 1
@@ -146,7 +153,9 @@ if ($BonsaiModel -eq "27B") {
     $Ctx = $CtxDefault
     $SpecArgs = @()
     if ($env:BONSAI_SPECULATIVE -eq "1") {
-        $Drafter = Get-ChildItem -Path $ModelDir -Filter *dspark-Q4_1*.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        # v7 builds read only converted (arch=dflash) drafters; convert the downloaded
+        # bf16 sidecar once with gguf-dspark-to-dflash (see SPECULATIVE.md)
+        $Drafter = Get-ChildItem -Path $ModelDir -Filter *dspark-dflash*.gguf -File -ErrorAction SilentlyContinue | Select-Object -First 1
         if ($Drafter) {
             $Nmax = if ($env:BONSAI_SPEC_NMAX) { $env:BONSAI_SPEC_NMAX } else { "4" }
             $SpecArgs = @("-md", $Drafter.FullName, "--spec-type", "draft-dspark", "--spec-draft-n-max", $Nmax, "-ngld", "999", "-np", "1")
@@ -156,7 +165,8 @@ if ($BonsaiModel -eq "27B") {
             if (-not $env:BONSAI_CTX -or $env:BONSAI_CTX -eq "0") { $Ctx = "16384" }
             Write-Host "  Speculative: $($Drafter.Name) (draft-dspark, n-max $Nmax)" -ForegroundColor Green
         } else {
-            Write-Host "[WARN] BONSAI_SPECULATIVE=1 but no *dspark-Q4_1*.gguf drafter in $ModelDir - running without speculation." -ForegroundColor Yellow
+            Write-Host "[WARN] BONSAI_SPECULATIVE=1 but no converted *dspark-dflash*.gguf drafter in $ModelDir - running without speculation." -ForegroundColor Yellow
+            Write-Host "       Convert the downloaded bf16 drafter once (see SPECULATIVE.md, section 'Converting the published drafter')." -ForegroundColor Yellow
         }
     }
     # 4-bit KV cache (opt-in, BONSAI_KV4=1): stores the KV cache in Q4_0 to cut

--- a/scripts/start_llama_server.ps1
+++ b/scripts/start_llama_server.ps1
@@ -42,13 +42,24 @@ if ($BonsaiFamily -eq "ternary") {
 $Display = "$FamilyDisplay-$BonsaiModel"
 # Select exactly the demo quant for the family (a leftover F16 or g64 file
 # must never be picked up).
-$QuantPattern = if ($BonsaiFamily -eq "ternary") { "*-Q2_0.gguf" } else { "*-Q1_0.gguf" }
-$Model = Get-ChildItem -Path $ModelDir -Filter $QuantPattern -File -ErrorAction SilentlyContinue |
-    Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
-    Select-Object -First 1
+$Model = $null
+if ($BonsaiFamily -eq "ternary") {
+    # PQ2_0 first (fork group-128; CPU/CUDA/HIP builds), then official group-64
+    # (*g64 on pre-v7 repos, plain *-Q2_0 on newer repos). Vulkan builds have no
+    # PQ2_0 kernels yet: set BONSAI_FORCE_G64=1 to skip PQ2_0. See MODEL-FORMATS.md.
+    $tryPatterns = if ($env:BONSAI_FORCE_G64 -eq "1") { @("*g64.gguf", "*-Q2_0.gguf") }
+                   else { @("*-PQ2_0.gguf", "*g64.gguf", "*-Q2_0.gguf") }
+} else {
+    $tryPatterns = @("*-Q1_0.gguf")
+}
+foreach ($qp in $tryPatterns) {
+    $Model = Get-ChildItem -Path $ModelDir -Filter $qp -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notlike "*mmproj*" -and $_.Name -notlike "*dspark*" -and $_.Name -notlike "*kv-bias*" } |
+        Select-Object -First 1
+    if ($Model) { break }
+}
 if (-not $Model) {
-    Write-Host "[ERR] No $QuantPattern model found for $Display in $ModelDir" -ForegroundColor Red
-
+    Write-Host "[ERR] No model file found for $Display in $ModelDir" -ForegroundColor Red
     Write-Host "      Run .\setup.ps1 first." -ForegroundColor Yellow
     exit 1
 }

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -95,7 +95,11 @@ if [ "$BONSAI_MODEL" = "27B" ]; then
     _spec_flags=""
     _ctx="$CTX_SIZE_DEFAULT"
     if [ "${BONSAI_SPECULATIVE:-0}" = "1" ]; then
-        for _md in "$GGUF_MODEL_DIR"/*dspark-Q4_1*.gguf; do
+        # v7 builds read only converted (arch=dflash) drafters; the published legacy
+        # *dspark-Q4_1/bf16 files must be run through gguf-dspark-to-dflash first.
+        # See SPECULATIVE.md for the two commands. Converted files keep "dspark-dflash"
+        # in their name so they are found here (and never picked as the main model).
+        for _md in "$GGUF_MODEL_DIR"/*dspark-dflash*.gguf; do
             [ -f "$_md" ] && MD="$DEMO_DIR/$_md" && break
         done
         if [ -n "$MD" ]; then
@@ -108,7 +112,8 @@ if [ "$BONSAI_MODEL" = "27B" ]; then
             case "${BONSAI_CTX:-0}" in 0|"") _ctx=16384 ;; esac
             echo "  Speculative: $(basename "$MD") (draft-dspark, n-max $_nmax)"
         else
-            warn "BONSAI_SPECULATIVE=1 but no *dspark-Q4_1*.gguf drafter in ${GGUF_MODEL_DIR}/; running without speculation."
+            warn "BONSAI_SPECULATIVE=1 but no converted *dspark-dflash*.gguf drafter in ${GGUF_MODEL_DIR}/; running without speculation."
+            echo "  Convert the published drafter once (see SPECULATIVE.md, section 'Converting the published drafter')."
             echo "  Re-run ./scripts/download_models.sh to fetch it."
         fi
     fi

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -22,19 +22,25 @@ if curl -s --max-time 2 "http://localhost:$PORT/health" >/dev/null 2>&1; then
     exit 1
 fi
 
-# ── Find model: select exactly the demo quant for the family
-#    (a leftover F16 or g64 file must never be picked up) ──
-MODEL=""
-for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
-    [ -f "$_m" ] || continue
-    case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
-    MODEL="$DEMO_DIR/$_m" && break
+# ── Find binary first (its backend decides the ternary quant; see common.sh) ──
+BIN=""
+for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
+    [ -f "$DEMO_DIR/$_d/llama-server" ] && BIN="$DEMO_DIR/$_d/llama-server" && break
 done
+if [ -z "$BIN" ]; then
+    err "llama-server not found. Run ./setup.sh or ./scripts/download_binaries.sh first."
+    exit 1
+fi
+BACKEND="$(backend_from_bin "$BIN")"
+
+# ── Find model: backend-aware selection, never the deprecated legacy Q2_0 ──
+MODEL="$(select_model_gguf "$GGUF_MODEL_DIR" "$BACKEND" || true)"
 if [ -z "$MODEL" ]; then
-    err "No ${GGUF_QUANT_PATTERN} model found in ${GGUF_MODEL_DIR}/."
+    err "No model file for ${BONSAI_DISPLAY} found in ${GGUF_MODEL_DIR}/."
     echo "  Re-run ./scripts/download_models.sh to fetch the model weights."
     exit 1
 fi
+MODEL="$DEMO_DIR/$MODEL"
 
 # ── Vision: use the multimodal projector when present (27B is a VLM) ──
 MMPROJ=""
@@ -44,16 +50,6 @@ done
 if [ "$BONSAI_MODEL" = "27B" ] && [ -z "$MMPROJ" ]; then
     warn "No mmproj file found in ${GGUF_MODEL_DIR}/ — image input disabled."
     echo "  Re-run ./scripts/download_models.sh to fetch it."
-fi
-
-# ── Find binary (search all known locations) ──
-BIN=""
-for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
-    [ -f "$DEMO_DIR/$_d/llama-server" ] && BIN="$DEMO_DIR/$_d/llama-server" && break
-done
-if [ -z "$BIN" ]; then
-    err "llama-server not found. Run ./setup.sh or ./scripts/download_binaries.sh first."
-    exit 1
 fi
 
 BIN_DIR="$(cd "$(dirname "$BIN")" && pwd)"

--- a/scripts/start_llama_server.sh
+++ b/scripts/start_llama_server.sh
@@ -13,7 +13,7 @@ assert_gguf_downloaded start_mlx_server.sh
 
 # Bind to localhost by default; override with BONSAI_HOST=0.0.0.0 for LAN/remote.
 HOST="${BONSAI_HOST:-127.0.0.1}"
-PORT=8080
+PORT="${PORT:-8080}"
 
 # ── Check port is free ──
 if curl -s --max-time 2 "http://localhost:$PORT/health" >/dev/null 2>&1; then

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -150,11 +150,8 @@ else
     # Find model + binary: select exactly the demo quant for the family
     # (a leftover F16 or g64 file must never be picked up).
     _model=""
-    for _m in $GGUF_MODEL_DIR/$GGUF_QUANT_PATTERN; do
-        [ -f "$_m" ] || continue
-        case "$_m" in *mmproj*|*dspark*|*kv-bias*) continue ;; esac
-        _model="$DEMO_DIR/$_m" && break
-    done
+    _model="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
+    [ -n "$_model" ] && _model="$DEMO_DIR/$_model"
     _bin=""
     for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do
         [ -f "$DEMO_DIR/$_d/llama-server" ] && _bin="$DEMO_DIR/$_d/llama-server" && break

--- a/scripts/start_openwebui.sh
+++ b/scripts/start_openwebui.sh
@@ -150,7 +150,11 @@ else
     # Find model + binary: select exactly the demo quant for the family
     # (a leftover F16 or g64 file must never be picked up).
     _model=""
-    _model="$(select_model_gguf "$GGUF_MODEL_DIR" || true)"
+    _owb_backend=""
+    for _bd in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu; do
+        [ -f "$_bd/llama-server" ] && _owb_backend="${_bd#bin/}" && break
+    done
+    _model="$(select_model_gguf "$GGUF_MODEL_DIR" "$_owb_backend" || true)"
     [ -n "$_model" ] && _model="$DEMO_DIR/$_model"
     _bin=""
     for _d in bin/mac bin/cuda bin/rocm bin/hip bin/vulkan bin/cpu llama.cpp/build/bin llama.cpp/build-mac/bin llama.cpp/build-cuda/bin; do

--- a/setup.ps1
+++ b/setup.ps1
@@ -229,7 +229,7 @@ function Download-GgufModel($Family, $Size) {
         $repo = "prism-ml/Ternary-Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\ternary-gguf\$Size"
         $display = "Ternary-Bonsai-$Size"
-        $pattern = "*-Q2_0.gguf"
+        $pattern = "*g64.gguf"
     } else {
         $repo = "prism-ml/Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\gguf\$Size"

--- a/setup.ps1
+++ b/setup.ps1
@@ -7,7 +7,10 @@ $PythonVersion = "3.11"
 $VenvDir = Join-Path $PSScriptRoot ".venv"
 $VenvPy  = Join-Path $VenvDir "Scripts\python.exe"
 
-$ReleaseTag = "prism-b9596-9fcaed7"
+# TODO(prism-v7 switch): set to the first prism-v7 release tag before merging.
+# v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
+# the legacy *-Q2_0.gguf files that pre-v7 releases used.
+$ReleaseTag = "prism-v7-TBD"
 $WinAssetTag = "prism-b1-9fcaed7"                    # Windows builds use shortened tag
 $BaseUrl = "https://github.com/PrismML-Eng/llama.cpp/releases/download/$ReleaseTag"
 
@@ -231,29 +234,36 @@ function Download-GgufModel($Family, $Size) {
         $display = "Ternary-Bonsai-$Size"
         # both ternary formats: PQ2_0 (fork group-128) and official group-64 Q2_0
         # (pre-v7 repos name it *_Q2_0_g64 / 27B *_Q2_g64); launcher picks per
-        # backend at runtime. See MODEL-FORMATS.md.
-        $pattern = "*-PQ2_0.gguf,*g64.gguf"
+        # backend at runtime. See MODEL-FORMATS.md. Must stay separate patterns:
+        # Get-ChildItem -Filter and the HF CLI both treat a comma string as one literal.
+        $patterns = @("*-PQ2_0.gguf", "*g64.gguf")
     } else {
         $repo = "prism-ml/Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\gguf\$Size"
         $display = "Bonsai-$Size"
-        $pattern = "*-Q1_0.gguf"
+        $patterns = @("*-Q1_0.gguf")
     }
 
     # 27B extras: the mmproj (multimodal projector) for image input, and the
     # paired dspark drafter for optional speculative decoding (BONSAI_SPECULATIVE=1).
     $mmprojPattern = if ($Size -eq "27B") { "*mmproj*.gguf" } else { $null }
-    $drafterPattern = if ($Size -eq "27B") { "*dspark-Q4_1*.gguf" } else { $null }
+    # bf16 drafter = conversion input for speculative decoding (see SPECULATIVE.md);
+    # the legacy Q4_1 sidecar cannot load on v7 builds
+    $drafterPattern = if ($Size -eq "27B") { "*dspark-bf16*.gguf" } else { $null }
 
     # Fast-path and post-download checks both filter on the target quant
     # pattern (not just any *.gguf) so a leftover F16 or other quant from an
     # earlier download doesn't get picked up at runtime. For 27B the fast-path
     # also requires the mmproj + drafter so a re-run backfills vision + speculative.
-    $quantPresent = Get-ChildItem -Path $dir -Filter $pattern -File -ErrorAction SilentlyContinue | Select-Object -First 1
+    $quantPresent = $null
+    foreach ($p in $patterns) {
+        $quantPresent = Get-ChildItem -Path $dir -Filter $p -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($quantPresent) { break }
+    }
     $mmprojPresent = if ($mmprojPattern) { Get-ChildItem -Path $dir -Filter $mmprojPattern -File -ErrorAction SilentlyContinue | Select-Object -First 1 } else { $true }
     $drafterPresent = if ($drafterPattern) { Get-ChildItem -Path $dir -Filter $drafterPattern -File -ErrorAction SilentlyContinue | Select-Object -First 1 } else { $true }
     if ($quantPresent -and $mmprojPresent -and $drafterPresent) {
-        Write-Host "[OK] GGUF $display ($pattern) already present." -ForegroundColor Green
+        Write-Host "[OK] GGUF $display ($($patterns -join ', ')) already present." -ForegroundColor Green
         return
     }
 
@@ -296,15 +306,28 @@ function Download-GgufModel($Family, $Size) {
         exit 1
     }
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    $HfArgs = @("download", $repo, "--local-dir", $dir, "--include", $pattern)
+    $HfArgs = @("download", $repo, "--local-dir", $dir)
+    foreach ($p in $patterns) { $HfArgs += @("--include", $p) }
     if ($mmprojPattern) { $HfArgs += @("--include", $mmprojPattern) }
     if ($drafterPattern) { $HfArgs += @("--include", $drafterPattern) }
     if ($env:BONSAI_TOKEN) { $env:HF_TOKEN = $env:BONSAI_TOKEN }  # pass via env (hf reads HF_TOKEN), not a CLI arg visible in the process list
     & $HfCli @HfArgs
     $DownloadExitCode = $LASTEXITCODE
-    $DownloadedGguf = Get-ChildItem -Path $dir -Filter $pattern -File -ErrorAction SilentlyContinue | Select-Object -First 1
+    $DownloadedGguf = $null
+    foreach ($p in $patterns) {
+        $DownloadedGguf = Get-ChildItem -Path $dir -Filter $p -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($DownloadedGguf) { break }
+    }
+    if (($DownloadExitCode -eq 0) -and (-not $DownloadedGguf) -and ($Family -eq "ternary")) {
+        # newer repos ship the official group-64 file as plain *-Q2_0.gguf with no *g64 name
+        Write-Host "==>    No PQ2_0/g64 file in $repo; falling back to *-Q2_0.gguf (official group-64 on current repos) ..."
+        & $HfCli download $repo --local-dir $dir --include "*-Q2_0.gguf"
+        $DownloadExitCode = $LASTEXITCODE
+        $DownloadedGguf = Get-ChildItem -Path $dir -Filter "*-Q2_0.gguf" -File -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($DownloadedGguf) { New-Item -ItemType File -Path (Join-Path $dir ".official-q2_0") -Force | Out-Null }
+    }
     if ($DownloadExitCode -ne 0 -or -not $DownloadedGguf) {
-        Write-Host "[ERR] Failed to download GGUF $display matching $pattern. Try running '$HfCli download $repo --local-dir $dir --include $pattern' manually." -ForegroundColor Red
+        Write-Host "[ERR] Failed to download GGUF $display matching $($patterns -join ', '). Try '$HfCli download $repo --local-dir $dir --include <pattern>' manually." -ForegroundColor Red
         exit 1
     }
     if ($mmprojPattern -and -not (Get-ChildItem -Path $dir -Filter $mmprojPattern -File -ErrorAction SilentlyContinue)) {

--- a/setup.ps1
+++ b/setup.ps1
@@ -7,10 +7,9 @@ $PythonVersion = "3.11"
 $VenvDir = Join-Path $PSScriptRoot ".venv"
 $VenvPy  = Join-Path $VenvDir "Scripts\python.exe"
 
-# TODO(prism-v7 switch): set to the first prism-v7 release tag before merging.
 # v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
 # the legacy *-Q2_0.gguf files that pre-v7 releases used.
-$ReleaseTag = "prism-v7-TBD"
+$ReleaseTag = "prism-b10658-4725def"
 $WinAssetTag = "prism-b1-9fcaed7"                    # Windows builds use shortened tag
 $BaseUrl = "https://github.com/PrismML-Eng/llama.cpp/releases/download/$ReleaseTag"
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -229,7 +229,10 @@ function Download-GgufModel($Family, $Size) {
         $repo = "prism-ml/Ternary-Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\ternary-gguf\$Size"
         $display = "Ternary-Bonsai-$Size"
-        $pattern = "*g64.gguf"
+        # both ternary formats: PQ2_0 (fork group-128) and official group-64 Q2_0
+        # (pre-v7 repos name it *_Q2_0_g64 / 27B *_Q2_g64); launcher picks per
+        # backend at runtime. See MODEL-FORMATS.md.
+        $pattern = "*-PQ2_0.gguf,*g64.gguf"
     } else {
         $repo = "prism-ml/Bonsai-${Size}-gguf"
         $dir = Join-Path $PSScriptRoot "models\gguf\$Size"

--- a/setup.sh
+++ b/setup.sh
@@ -259,17 +259,19 @@ uv sync
 info "Base deps installed (cmake, ninja, setuptools, huggingface-cli)."
 
 # ────────────────────────────────────────────────────
-#  6. Download models from HuggingFace
+#  6. llama.cpp pre-built binaries
+# ────────────────────────────────────────────────────
+# Binaries come FIRST so the model downloader knows the backend and fetches a
+# single ternary format (PQ2_0 where the backend has kernels, group-64 Q2_0
+# otherwise) instead of both. The downloader fast-skips when the installed
+# binaries already match the pinned release, and refreshes on a pin change.
+sh "$SCRIPT_DIR/scripts/download_binaries.sh"
+
+# ────────────────────────────────────────────────────
+#  7. Download models from HuggingFace
 # ────────────────────────────────────────────────────
 step "Model download (BONSAI_FAMILY=${BONSAI_FAMILY} BONSAI_MODEL=${BONSAI_MODEL}) ..."
 BONSAI_FAMILY="$BONSAI_FAMILY" BONSAI_MODEL="$BONSAI_MODEL" sh "$SCRIPT_DIR/scripts/download_models.sh"
-
-# ────────────────────────────────────────────────────
-#  7. llama.cpp pre-built binaries
-# ────────────────────────────────────────────────────
-# Always defer to the downloader: it fast-skips when the installed binaries
-# already match the pinned release, and refreshes them when the pin changed.
-sh "$SCRIPT_DIR/scripts/download_binaries.sh"
 
 chmod +x "$SCRIPT_DIR"/scripts/*.sh 2>/dev/null || true
 


### PR DESCRIPTION
Prepares the demo for the prism branch switch to prism-v7. DRAFT until the first prism-v7 release tag is set.

## Model selection policy (PQ2_0-first)

Ternary selection is backend-aware via `select_model_gguf` + the `pq2_0_ready_backend` registry in scripts/common.sh: **PQ2_0 first** on Metal/CUDA/ROCm/HIP/CPU, official group-64 Q2_0 on Vulkan (and any backend without PQ2_0 kernels). Fallback order per backend: `*-PQ2_0.gguf` -> `*g64.gguf` (pre-v7 repos, covers the 27B `Q2_g64` spelling) -> plain `*-Q2_0.gguf`, which is trusted only with the downloader's `.official-q2_0` marker so a deprecated legacy leftover from a pre-v7 install is never picked (the download prompt fires instead). Windows launchers mirror the same logic, deriving the backend from the resolved binary; `BONSAI_FORCE_G64=1` remains as an explicit override.

## Downloads

Backend-aware single-format fetch (PQ2_0 or g64) when a binary is installed, both formats otherwise; plain-`Q2_0` fallback (+ marker) for future repos that drop the g64 suffix, on both bash and PowerShell. The 27B extras now fetch the **bf16 dspark drafter** (the conversion input) instead of the legacy Q4_1 that v7 cannot load.

## Speculative decoding

Launchers select converted `*dspark-dflash*.gguf` drafters and print conversion guidance when absent. SPECULATIVE.md documents the one-time `gguf-dspark-to-dflash --drop-shared-tensors` + `llama-quantize Q4_0` conversion with measured numbers (+29% Metal, +73-93% CUDA on the 27B).

## Also

- MODEL-FORMATS.md: the three formats, exact per-size file names, deprecation story, backend table.
- `PORT` env override for start_llama_server.sh (documented in environment_variables.md).
- `download_binaries.sh` / setup.ps1 release pins are marked TODO(`prism-v7-TBD`) pending the first prism-v7 release tag.

## Tested locally against a prism-v7 build (Metal, M5 Max)

1.7B + 27B server launches (PQ2_0 selected, mmproj loaded), speculative decode through the launcher with a converted drafter, run_llama/make_kv_bias selection, selection-matrix unit tests incl. Vulkan/SYCL fallback and the legacy-leftover refusal, fresh-download + re-run fast path in a scratch clone.

## Before un-drafting

- [ ] First prism-v7 release cut; set RELEASE_TAG in download_binaries.sh and setup.ps1
- [ ] Fresh-clone setup.sh E2E against the released binaries (Linux + macOS)
- [ ] Windows setup.ps1 + launcher pass on a real Windows machine
- [ ] README Upstream Status section refresh