### PR TITLE
bump binaries to prism-b10660-e311ed3, drop the win asset-name workaround

### DIFF
--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -12,7 +12,7 @@ cd "$DEMO_DIR"
 
 # v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
 # the legacy *-Q2_0.gguf files that pre-v7 releases used.
-RELEASE_TAG="prism-b10658-4725def"
+RELEASE_TAG="prism-b10660-e311ed3"
 BASE_URL="https://github.com/PrismML-Eng/llama.cpp/releases/download/$RELEASE_TAG"
 
 OS="$(uname -s)"

--- a/setup.ps1
+++ b/setup.ps1
@@ -9,11 +9,7 @@ $VenvPy  = Join-Path $VenvDir "Scripts\python.exe"
 
 # v7 binaries read the official group-64 Q2_0 files and PQ2_0; they do NOT read
 # the legacy *-Q2_0.gguf files that pre-v7 releases used.
-$ReleaseTag = "prism-b10658-4725def"
-# The windows-cuda release job currently misnumbers its asset as b1-<sha> (fork
-# issue #111, fixed by llama.cpp #132); until a release ships that fix, the CUDA
-# zip must be addressed by this literal name. Keep in sync with $ReleaseTag's sha.
-$WinAssetTag = "prism-b1-4725def"
+$ReleaseTag = "prism-b10660-e311ed3"
 $BaseUrl = "https://github.com/PrismML-Eng/llama.cpp/releases/download/$ReleaseTag"
 
 $BonsaiModel  = if ($env:BONSAI_MODEL)  { $env:BONSAI_MODEL }  else { "27B" }
@@ -400,7 +396,7 @@ if ($GpuType -eq "hip") {
     Download-Binary "llama-bin-win-hip-radeon-x64.zip" $BinDir
 } elseif ($GpuType -eq "cuda") {
     $BinDir = Join-Path $PSScriptRoot "bin\cuda"
-    Download-Binary "llama-${WinAssetTag}-bin-win-cuda-${CudaTag}-x64.zip" $BinDir
+    Download-Binary "llama-${ReleaseTag}-bin-win-cuda-${CudaTag}-x64.zip" $BinDir
 
     # Also download CUDA runtime DLLs
     $DllAsset = "cudart-llama-bin-win-cuda-${CudaTag}-x64.zip"


### PR DESCRIPTION
Pins the demo to [prism-b10660-e311ed3](https://github.com/PrismML-Eng/llama.cpp/releases/tag/prism-b10660-e311ed3), the first release with correctly named Windows assets (fork #111, fixed by llama.cpp #132 + #133).

- `setup.ps1`: `$ReleaseTag` bumped; the `$WinAssetTag = "prism-b1-4725def"` literal from #152 is gone — the CUDA zip is addressed by the real tag again.
- `scripts/download_binaries.sh`: same bump.

The new release also adds win-cuda 13.3 x64, a win-cuda 13.4 arm64 companion dll, linux-cuda 13.3, and android-arm64 builds, so newer CUDA toolkits on Windows/Linux get native binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)