### PR TITLE
select the cuda 13.3 builds when the detected version supports them

### DIFF
--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -106,12 +106,15 @@ URL="$BASE_URL/$ASSET"
 
 if [ -d "$DEST" ] && ls "$DEST"/llama-* >/dev/null 2>&1; then
     _installed=""
+    # The stamp includes the CUDA variant so a resolver change (e.g. 12.8 -> 13.3)
+    # refreshes an existing install of the same release.
+    _stamp="$RELEASE_TAG${_cuda_tag:+ cuda-$_cuda_tag}"
     [ -f "$DEST/.llama_release" ] && _installed="$(cat "$DEST/.llama_release" 2>/dev/null)"
-    if [ "$_installed" = "$RELEASE_TAG" ]; then
-        info "Binaries already present in $DEST/ ($RELEASE_TAG)."
+    if [ "$_installed" = "$_stamp" ]; then
+        info "Binaries already present in $DEST/ ($_stamp)."
         exit 0
     fi
-    warn "Binaries in $DEST/ are ${_installed:-an older/unknown release}; updating to $RELEASE_TAG ..."
+    warn "Binaries in $DEST/ are ${_installed:-an older/unknown release}; updating to $_stamp ..."
     rm -rf "$DEST"
 fi
 
@@ -185,7 +188,8 @@ fi
 
 # Record the installed release so re-running setup can detect a version bump
 # and refresh the binaries instead of keeping the old ones.
-printf '%s\n' "$RELEASE_TAG" > "$DEST/.llama_release"
+_stamp="$RELEASE_TAG${_cuda_tag:+ cuda-$_cuda_tag}"
+printf '%s\n' "$_stamp" > "$DEST/.llama_release"
 
 info "Binaries installed to $DEST/ ($RELEASE_TAG)"
 ls -lh "$DEST"/llama-* 2>/dev/null || true

--- a/scripts/download_binaries.sh
+++ b/scripts/download_binaries.sh
@@ -65,7 +65,9 @@ case "$OS" in
         if [ "$_gpu_type" = "cuda" ]; then
             _major="${_cuda_ver%%.*}"
             _minor="${_cuda_ver#*.}"
-            if [ "$_major" -ge 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
+            if [ "$_major" -gt 13 ] || { [ "$_major" -eq 13 ] && [ "$_minor" -ge 3 ]; }; then
+                _cuda_tag="13.3"
+            elif [ "$_major" -eq 13 ] || { [ "$_major" -eq 12 ] && [ "$_minor" -ge 8 ]; }; then
                 _cuda_tag="12.8"
             elif [ "$_major" -eq 12 ]; then
                 _cuda_tag="12.4"

--- a/setup.ps1
+++ b/setup.ps1
@@ -169,7 +169,10 @@ foreach ($p in @(
             $out = & $p 2>&1 | Out-String
             if ($out -match 'CUDA Version:\s+(\d+)\.(\d+)') {
                 $major = [int]$Matches[1]; $minor = [int]$Matches[2]
-                if ($major -gt 12 -or ($major -eq 12 -and $minor -ge 4)) {
+                if ($major -gt 13 -or ($major -eq 13 -and $minor -ge 3)) {
+                    $CudaTag = "13.3"
+                    $GpuType = "cuda"
+                } elseif ($major -gt 12 -or ($major -eq 12 -and $minor -ge 4)) {
                     $CudaTag = "12.4"
                     $GpuType = "cuda"
                 } else {

--- a/setup.ps1
+++ b/setup.ps1
@@ -387,9 +387,12 @@ foreach ($binRelDir in @("bin\hip", "bin\cuda", "bin\vulkan", "bin\cpu")) {
     $stampFile = Join-Path $binDir ".llama_release"
     $installedTag = if (Test-Path $stampFile) { (Get-Content -Raw $stampFile).Trim() } else { "" }
 
-    if ($installedTag -ne $ReleaseTag) {
+    # The stamp includes the CUDA variant so a resolver change (e.g. 12.4 -> 13.3)
+    # refreshes an existing install of the same release.
+    $expectedStamp = if ($GpuType -eq "cuda") { "$ReleaseTag cuda-$CudaTag" } else { $ReleaseTag }
+    if ($installedTag -ne $expectedStamp) {
         $was = if ($installedTag) { $installedTag } else { "an older/unknown release" }
-        Write-Host "[WARN] Binaries in $binRelDir are $was; updating to $ReleaseTag ..." -ForegroundColor Yellow
+        Write-Host "[WARN] Binaries in $binRelDir are $was; updating to $expectedStamp ..." -ForegroundColor Yellow
         Remove-Item -Recurse -Force $binDir
     }
 }
@@ -426,7 +429,7 @@ if ($GpuType -eq "hip") {
 
 # Record the installed release so a future setup detects a version bump and
 # refreshes the binaries instead of keeping the old ones.
-if ($BinDir) { Set-Content -Path (Join-Path $BinDir ".llama_release") -Value $ReleaseTag -NoNewline -Encoding utf8 }
+if ($BinDir) { $finalStamp = if ($GpuType -eq "cuda") { "$ReleaseTag cuda-$CudaTag" } else { $ReleaseTag }; Set-Content -Path (Join-Path $BinDir ".llama_release") -Value $finalStamp -NoNewline -Encoding utf8 }
 
 # ── Done ──
 Write-Host ""


### PR DESCRIPTION
Follow-up to the post-merge review on #154: the release ships CUDA 13.3 assets for Linux and Windows, but both resolvers still mapped newer toolkits to the older builds (every 13.x to 12.8 on Linux, everything to 12.4 on Windows), so the claimed native support never engaged.

Now detected CUDA >= 13.3 selects the 13.3 asset on both platforms; 12.8 <= version < 13.3 keeps the 12.8 build on Linux (forward-compatible via driver), and 12.x keeps the existing behavior. The Windows cudart zip uses the same tag variable, and all three 13.3 asset URLs verify as present on the pinned release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)