### PR TITLE
community-benchmarks: warn about the 27B Q2_g64 filename trap

### DIFF
--- a/community-benchmarks/ternary-bonsai/README.md
+++ b/community-benchmarks/ternary-bonsai/README.md
@@ -37,6 +37,7 @@ Since the llama.cpp fork's rebase onto current mainline (releases `prism-b10658`
 - **`PQ2_0`** — our group-128 packing (`*-PQ2_0.gguf`). Smallest file (27B: 6.66 GiB) and usually fastest where supported (CUDA, Metal, CPU, ROCm).
 - **`Q2_0` group-64** — the official upstream format (27B: `Ternary-Bonsai-27B-Q2_g64.gguf`; 8B/4B/1.7B: `*-Q2_0_g64.gguf`). Slightly larger (27B: 7.05 GiB), widest backend coverage (adds Vulkan and SYCL).
 - The **legacy `*-Q2_0.gguf` files** (no `g64` in the name) predate the migration: they still work on the old `prism-v5` releases, but `prism-b10658+` builds refuse them with an error pointing at the two formats above. Don't benchmark those on new builds.
+- **Filename trap:** on the 27B repo a search for `Q2_0` surfaces the legacy file first, and a search for `Q2_0_g64` finds nothing (the 27B file is `Q2_g64`). If the only Q2 file you see is `Ternary-Bonsai-27B-Q2_0.gguf`, keep looking: `hf download prism-ml/Ternary-Bonsai-27B-GGUF --include "*PQ2_0*" --include "*g64*"` fetches both current formats.
 
 Repos:
 

--- a/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
+++ b/community-benchmarks/ternary-bonsai/TERNARY-TEMPLATE-llama-cpp.md
@@ -27,6 +27,12 @@
     prism-b10658+ binaries refuse them with a clear error. If the user has old files or
     old binaries, point them at the new release and the two files above instead of
     benchmarking the legacy pair.
+    FILENAME TRAP (this has burned an agent before): on the 27B repo, searching for
+    "Q2_0" finds the legacy Ternary-Bonsai-27B-Q2_0.gguf FIRST, and searching for
+    "Q2_0_g64" finds NOTHING, because the 27B group-64 file is named Q2_g64 (unlike
+    the smaller sizes). Do not conclude the group-64 file is missing. Fetch both
+    current 27B formats in one command:
+      hf download prism-ml/Ternary-Bonsai-27B-GGUF --include "*PQ2_0*" --include "*g64*" --local-dir models/ternary-gguf/27B
 -->
 
 ## Summary


### PR DESCRIPTION
Hardening after #156, where a submitter's agent searched the 27B repo for the group-64 file, found only the legacy `Ternary-Bonsai-27B-Q2_0.gguf` (searching "Q2_0" surfaces it first, and "Q2_0_g64" matches nothing since the 27B file is named `Q2_g64`), and wrongly reported that no group-64 file exists.

The template's AI-assistant notes and the ternary README now call the trap out explicitly and give a single `hf download` command that fetches both current formats. The false claim in #156's entry is corrected on that PR's branch separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)